### PR TITLE
Harden startup defaults, safe download behavior, and graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 - 本项目是基于 [clash](https://github.com/Dreamacro/clash) 、[yacd](https://github.com/haishanh/yacd) 进行的配置整合，关于clash、yacd的详细配置请去原项目查看。
 - 此项目不提供任何订阅信息，请自行准备Clash订阅地址。
 - 运行前请手动更改`.env`文件中的`CLASH_URL`变量值，否则无法正常运行。
+- 默认将管理面板仅绑定到本机（`127.0.0.1:9090`），如需对外访问请在`.env`中自行配置并确保`CLASH_SECRET`足够复杂。
+- 默认开启 TLS 证书校验，若确需跳过校验请在`.env`中设置`ALLOW_INSECURE_TLS=true`（不推荐）。
 - 当前在RHEL系列和Debian系列Linux系统中测试过，其他系列可能需要适当修改脚本。
 - 支持 x86_64/aarch64 平台
 
@@ -71,7 +73,7 @@ Clash订阅地址可访问！                                      [  OK  ]
 Clash Dashboard 访问地址：http://<ip>:9090/ui
 Secret：xxxxxxxxxxxxx
 
-请执行以下命令加载环境变量: source /etc/profile.d/clash.sh
+请执行以下命令加载环境变量: source /etc/profile.d/clash-for-linux.sh
 
 请执行以下命令开启系统代理: proxy_on
 
@@ -80,7 +82,7 @@ Secret：xxxxxxxxxxxxx
 ```
 
 ```bash
-$ source /etc/profile.d/clash.sh
+$ source /etc/profile.d/clash-for-linux.sh
 $ proxy_on
 ```
 

--- a/restart.sh
+++ b/restart.sh
@@ -45,12 +45,21 @@ Log_Dir="$Server_Dir/logs"
 Text1="服务关闭成功！"
 Text2="服务关闭失败！"
 # 查询并关闭程序进程
-PID_NUM=`ps -ef | grep [c]lash-linux-a | wc -l`
-PID=`ps -ef | grep [c]lash-linux-a | awk '{print $2}'`
-if [ $PID_NUM -ne 0 ]; then
-	kill -9 $PID
-  ReturnStatus=$?
-	# ps -ef | grep [c]lash-linux-a | awk '{print $2}' | xargs kill -9
+PIDS=$(pgrep -f "clash-linux-")
+if [ -n "$PIDS" ]; then
+	kill $PIDS
+	ReturnStatus=$?
+	for i in {1..5}; do
+		sleep 1
+		if ! pgrep -f "clash-linux-" >/dev/null; then
+			break
+		fi
+	done
+	if pgrep -f "clash-linux-" >/dev/null; then
+		kill -9 $PIDS
+	fi
+else
+	ReturnStatus=0
 fi
 if_success $Text1 $Text2 $ReturnStatus
 
@@ -87,4 +96,3 @@ else
 	echo -e "\033[31m\n[ERROR] Unsupported CPU Architecture！\033[0m"
 	exit 1
 fi
-

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
 # 关闭clash服务
-PID_NUM=`ps -ef | grep [c]lash-linux-a | wc -l`
-PID=`ps -ef | grep [c]lash-linux-a | awk '{print $2}'`
-if [ $PID_NUM -ne 0 ]; then
-	kill -9 $PID
-	# ps -ef | grep [c]lash-linux-a | awk '{print $2}' | xargs kill -9
+PIDS=$(pgrep -f "clash-linux-")
+if [ -n "$PIDS" ]; then
+	kill $PIDS
+	for i in {1..5}; do
+		sleep 1
+		if ! pgrep -f "clash-linux-" >/dev/null; then
+			break
+		fi
+	done
+	if pgrep -f "clash-linux-" >/dev/null; then
+		kill -9 $PIDS
+	fi
 fi
 
 # 清除环境变量
-> /etc/profile.d/clash.sh
+> /etc/profile.d/clash-for-linux.sh
 
 echo -e "\n服务关闭成功，请执行以下命令关闭系统代理：proxy_off\n"


### PR DESCRIPTION
### Motivation
- Reduce attack surface by defaulting the dashboard to localhost and disabling LAN access. 
- Avoid unsafe `eval` usage and make TLS validation opt-in for subscription downloads. 
- Improve process shutdown to prefer graceful termination before forcing kills. 
- Separate the shell profile script name to avoid colliding with other packages.

### Description
- In `start.sh` set `CLASH_ALLOW_LAN=false`, default `EXTERNAL_CONTROLLER=127.0.0.1:9090`, and add `ALLOW_INSECURE_TLS=false` as an opt-in flag. 
- Replace `eval`-built `curl`/`wget` strings with command arrays and honor `ALLOW_INSECURE_TLS` to optionally add `-k`/`--no-check-certificate` while printing a warning when insecure TLS is enabled. 
- Check subscription HTTP status by capturing `status_code=$("${CHECK_CMD[@]}")` and validate it instead of piping an `eval` call. 
- Replace `ps | grep` logic in `restart.sh` and `shutdown.sh` with `pgrep -f "clash-linux-"`, perform a graceful `kill` and wait up to a few seconds before falling back to `kill -9`, and update profile script name to `/etc/profile.d/clash-for-linux.sh` across scripts and `README.md`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696658ea3138833189ca721578dcb28b)