### PR TITLE
Add systemd installer, non-root service user, and multi-arch subconverter resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,10 @@ $ proxy_off
 
 ## systemd 服务
 
-将仓库中的 `systemd/clash-for-linux.service` 复制到 `/etc/systemd/system/`，并根据实际路径修改 `WorkingDirectory` 与脚本路径：
+推荐使用自动安装脚本生成 systemd 单元（自动识别安装路径、创建低权限用户并修正目录权限）：
 
 ```bash
-$ sudo cp systemd/clash-for-linux.service /etc/systemd/system/
-$ sudo vim /etc/systemd/system/clash-for-linux.service
+$ sudo bash scripts/install_systemd.sh
 ```
 
 启用并启动服务：
@@ -178,6 +177,41 @@ $ sudo systemctl enable --now clash-for-linux.service
 ```bash
 $ sudo systemctl stop clash-for-linux.service
 ```
+
+> 如需自定义运行用户，可在执行脚本前设置 `CLASH_SERVICE_USER`（可选 `CLASH_SERVICE_GROUP`）。
+> 默认使用 `clash` 用户运行服务，systemd 环境文件输出到 `temp/clash-for-linux.sh`。
+
+如果需要手动安装，可参考 `systemd/clash-for-linux.service` 模板并替换安装路径。
+
+
+<br>
+
+## subconverter 多架构支持
+
+`subconverter` 用于将订阅内容转换为标准 clash 配置。默认会尝试以下位置：
+
+- `tools/subconverter/subconverter`
+- `tools/subconverter/subconverter-<arch>`
+- `tools/subconverter/bin/subconverter-<arch>`
+
+其中 `<arch>` 取值为：
+
+- `linux-amd64`
+- `linux-arm64`
+- `linux-armv7`
+
+你也可以设置：
+
+- `SUBCONVERTER_PATH`：指定自定义 `subconverter` 可执行文件路径。
+- `SUBCONVERTER_AUTO_DOWNLOAD=true`：启用自动下载（需 `curl`/`wget`）。
+- `SUBCONVERTER_DOWNLOAD_URL_TEMPLATE`：下载模板，使用 `{arch}` 占位符，如：
+
+```bash
+export SUBCONVERTER_AUTO_DOWNLOAD=true
+export SUBCONVERTER_DOWNLOAD_URL_TEMPLATE='https://example.com/subconverter_{arch}.tar.gz'
+```
+
+当 `subconverter` 不可用时会自动跳过转换，并提示警告。
 
 
 <br>

--- a/scripts/clash_profile_conversion.sh
+++ b/scripts/clash_profile_conversion.sh
@@ -21,7 +21,11 @@ else
       echo "$decoded_content" > ${Server_Dir}/temp/clash_config.yaml
     else
       echo "解码后的内容不符合clash标准，尝试将其转换为标准格式"
-      ${Server_Dir}/tools/subconverter/subconverter -g &>> ${Server_Dir}/logs/subconverter.log
+      if [ -z "$SUBCONVERTER_BIN" ]; then
+        echo "subconverter 未配置，无法执行转换"
+        exit 1
+      fi
+      "${SUBCONVERTER_BIN}" -g &>> ${Server_Dir}/logs/subconverter.log
       converted_file=${Server_Dir}/temp/clash_config.yaml
       # 判断转换后的内容是否符合clash配置文件标准
       if awk '/^proxies:/{p=1} /^proxy-groups:/{g=1} /^rules:/{r=1} p&&g&&r{exit} END{if(p&&g&&r) exit 0; else exit 1}' $converted_file; then

--- a/scripts/install_systemd.sh
+++ b/scripts/install_systemd.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+Server_Dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+Service_Name="clash-for-linux"
+Service_User="${CLASH_SERVICE_USER:-clash}"
+Service_Group="${CLASH_SERVICE_GROUP:-$Service_User}"
+Unit_Path="/etc/systemd/system/${Service_Name}.service"
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo -e "\033[31m[ERROR] 需要 root 权限来安装 systemd 单元\033[0m"
+	exit 1
+fi
+
+if ! getent group "$Service_Group" >/dev/null 2>&1; then
+	groupadd --system "$Service_Group"
+fi
+
+if ! id "$Service_User" >/dev/null 2>&1; then
+	useradd --system --no-create-home --shell /usr/sbin/nologin --gid "$Service_Group" "$Service_User"
+fi
+
+install -d -m 0755 "$Server_Dir/conf" "$Server_Dir/logs" "$Server_Dir/temp"
+chown -R "$Service_User:$Service_Group" "$Server_Dir/conf" "$Server_Dir/logs" "$Server_Dir/temp"
+
+cat >"$Unit_Path"<<EOF
+[Unit]
+Description=Clash for Linux
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$Server_Dir
+ExecStart=/bin/bash $Server_Dir/start.sh
+ExecStop=/bin/bash $Server_Dir/shutdown.sh
+Restart=on-failure
+RestartSec=5
+User=$Service_User
+Group=$Service_Group
+PIDFile=$Server_Dir/temp/clash.pid
+Environment=CLASH_ENV_FILE=$Server_Dir/temp/clash-for-linux.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+
+echo -e "\033[32m[OK] 已生成 systemd 单元: ${Unit_Path}\033[0m"
+echo -e "可执行以下命令启动服务："
+echo -e "  sudo systemctl enable --now ${Service_Name}.service"

--- a/scripts/resolve_subconverter.sh
+++ b/scripts/resolve_subconverter.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+Subconverter_Bin=""
+Subconverter_Ready=false
+
+Subconverter_Dir="${Server_Dir}/tools/subconverter"
+Default_Bin="${Subconverter_Dir}/subconverter"
+
+resolve_subconverter_arch() {
+	local raw_arch="$1"
+	case "$raw_arch" in
+		x86_64|amd64)
+			echo "linux-amd64"
+			;;
+		aarch64|arm64)
+			echo "linux-arm64"
+			;;
+		armv7*|armv7l)
+			echo "linux-armv7"
+			;;
+		*)
+			echo ""
+			;;
+	esac
+}
+
+try_subconverter_bin() {
+	local candidate="$1"
+	if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+		Subconverter_Bin="$candidate"
+		Subconverter_Ready=true
+		return 0
+	fi
+	return 1
+}
+
+if [ -n "$SUBCONVERTER_PATH" ]; then
+	try_subconverter_bin "$SUBCONVERTER_PATH" && return 0
+else
+	try_subconverter_bin "$Default_Bin" && return 0
+fi
+
+Detected_Arch="${CpuArch:-$(uname -m 2>/dev/null)}"
+Resolved_Arch=$(resolve_subconverter_arch "$Detected_Arch")
+
+if [ -n "$Resolved_Arch" ]; then
+	try_subconverter_bin "${Subconverter_Dir}/subconverter-${Resolved_Arch}" && return 0
+	try_subconverter_bin "${Subconverter_Dir}/bin/subconverter-${Resolved_Arch}" && return 0
+	try_subconverter_bin "${Subconverter_Dir}/${Resolved_Arch}/subconverter" && return 0
+fi
+
+if [ "${SUBCONVERTER_AUTO_DOWNLOAD:-false}" = "true" ] && [ -n "$Resolved_Arch" ]; then
+	Download_Template="${SUBCONVERTER_DOWNLOAD_URL_TEMPLATE:-}"
+	if [ -z "$Download_Template" ]; then
+		echo -e "\033[33m[WARN] 未设置 SUBCONVERTER_DOWNLOAD_URL_TEMPLATE，跳过 subconverter 自动下载\033[0m"
+		return 0
+	fi
+
+	Download_Url="${Download_Template//\{arch\}/${Resolved_Arch}}"
+	Download_Archive="${Server_Dir}/temp/subconverter-${Resolved_Arch}.tar.gz"
+	Extract_Dir="${Server_Dir}/temp/subconverter-${Resolved_Arch}"
+	mkdir -p "${Extract_Dir}"
+
+	if command -v curl >/dev/null 2>&1; then
+		curl -L -sS -o "${Download_Archive}" "${Download_Url}"
+	elif command -v wget >/dev/null 2>&1; then
+		wget -q -O "${Download_Archive}" "${Download_Url}"
+	else
+		echo -e "\033[33m[WARN] 未找到 curl 或 wget，无法自动下载 subconverter\033[0m"
+		return 0
+	fi
+
+	if [ -f "${Download_Archive}" ]; then
+		tar -xzf "${Download_Archive}" -C "${Extract_Dir}" 2>/dev/null
+		Downloaded_Bin=$(find "${Extract_Dir}" -maxdepth 3 -type f -name "subconverter" -print -quit)
+		if [ -n "${Downloaded_Bin}" ]; then
+			mv "${Downloaded_Bin}" "${Subconverter_Dir}/subconverter-${Resolved_Arch}"
+			chmod +x "${Subconverter_Dir}/subconverter-${Resolved_Arch}"
+			try_subconverter_bin "${Subconverter_Dir}/subconverter-${Resolved_Arch}" && return 0
+		fi
+	fi
+fi

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -36,6 +36,18 @@ else
 fi
 
 # 清除环境变量
-> /etc/profile.d/clash-for-linux.sh
+Env_File="${CLASH_ENV_FILE:-}"
+if [ "$Env_File" != "off" ] && [ "$Env_File" != "disabled" ]; then
+	if [ -z "$Env_File" ]; then
+		if [ -w /etc/profile.d ]; then
+			Env_File="/etc/profile.d/clash-for-linux.sh"
+		else
+			Env_File="$Temp_Dir/clash-for-linux.sh"
+		fi
+	fi
+	if [ -f "$Env_File" ]; then
+		> "$Env_File"
+	fi
+fi
 
 echo -e "\n服务关闭成功，请执行以下命令关闭系统代理：proxy_off\n"

--- a/systemd/clash-for-linux.service
+++ b/systemd/clash-for-linux.service
@@ -9,8 +9,10 @@ ExecStart=/bin/bash /opt/clash-for-linux/start.sh
 ExecStop=/bin/bash /opt/clash-for-linux/shutdown.sh
 Restart=on-failure
 RestartSec=5
-User=root
+User=clash
+Group=clash
 PIDFile=/opt/clash-for-linux/temp/clash.pid
+Environment=CLASH_ENV_FILE=/opt/clash-for-linux/temp/clash-for-linux.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/update.sh
+++ b/update.sh
@@ -152,8 +152,10 @@ if_success $Text3 $Text4 $ReturnStatus
 \cp -a $Temp_Dir/clash.yaml $Temp_Dir/clash_config.yaml
 
 ## 判断订阅内容是否符合clash配置文件标准，尝试转换（需 subconverter 可执行文件支持）
-if [ -x "$Server_Dir/tools/subconverter/subconverter" ]; then
+source $Server_Dir/scripts/resolve_subconverter.sh
+if [ "$Subconverter_Ready" = "true" ]; then
 	echo -e '\n判断订阅内容是否符合clash配置文件标准:'
+	export SUBCONVERTER_BIN="$Subconverter_Bin"
 	bash $Server_Dir/scripts/clash_profile_conversion.sh
 	sleep 3
 else


### PR DESCRIPTION
### Motivation
- Provide an automated way to install a `systemd` unit so users no longer need to manually edit paths in the template.
- Reduce reliance on running everything as `root` by creating a low-privilege service user and writing environment files to a writable location.
- Improve subscription conversion reliability by resolving multi-architecture `subconverter` binaries and supporting optional auto-download when available.

### Description
- Add `scripts/install_systemd.sh` which auto-detects the install path, creates a service user/group, fixes directory ownership, and writes a unit with `Environment=CLASH_ENV_FILE`.
- Add `scripts/resolve_subconverter.sh` to locate per-arch `subconverter` binaries (and optionally download them using a `SUBCONVERTER_DOWNLOAD_URL_TEMPLATE`) and export the resolved path as `SUBCONVERTER_BIN`.
- Update `start.sh` and `update.sh` to source the resolver and export `SUBCONVERTER_BIN`, to guard `chmod` calls, and to write the env file to a non-root path (or follow `CLASH_ENV_FILE`) instead of always writing `/etc/profile.d`.
- Update `scripts/clash_profile_conversion.sh`, `shutdown.sh`, `systemd/clash-for-linux.service`, and `README.md` to use the new resolver, respect the env file configuration, default to a non-root `clash` user, and document multi-arch `subconverter` options.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69666774c6788331bb5fa060bf3c1e52)