### PR TITLE
Flexible Clash binary detection, PID/env overrides, and systemd env template

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,8 @@
 export CLASH_URL='更改为你的clash订阅地址'
 export CLASH_SECRET=''
 export CLASH_HEADERS='User-Agent: ClashforWindows/0.20.39'
+# 可选：指定 Clash 二进制路径（适用于额外架构或自定义位置）
+# export CLASH_BIN='/path/to/clash'
 
 # Clash 监听配置
 export CLASH_HTTP_PORT=7890

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # 使用须知
 
-- 运行本项目建议使用root用户，或者使用 sudo 提权。
+- 支持普通用户运行，涉及 systemd 安装/端口转发等系统级操作时需要 root 或 sudo。
 - 使用过程中如遇到问题，请优先查已有的 [issues](https://github.com/wanhebin/clash-for-linux/issues)。
 - 在进行issues提交前，请替换提交内容中是敏感信息（例如：订阅地址）。
 - 本项目是基于 [clash](https://github.com/Dreamacro/clash) 、[yacd](https://github.com/haishanh/yacd) 进行的配置整合，关于clash、yacd的详细配置请去原项目查看。
@@ -20,7 +20,7 @@
 - 默认开启 TLS 证书校验，若确需跳过校验请在`.env`中设置`ALLOW_INSECURE_TLS=true`（不推荐）。
 - 如从旧版本升级，若存在 `/etc/profile.d/clash.sh` 请按需清理或改用新的 `/etc/profile.d/clash-for-linux.sh`。
 - 当前在RHEL系列和Debian系列Linux系统中测试过，其他系列可能需要适当修改脚本。
-- 支持 x86_64/aarch64 平台
+- 内置 Clash 二进制支持 x86_64/aarch64/armv7，其它架构可自行放置二进制并通过 `CLASH_BIN` 指定路径。
 
 > **注意**：当你在使用此项目时，遇到任何无法独自解决的问题请优先前往 [Issues](https://github.com/wanhebin/clash-for-linux/issues) 寻找解决方法。由于空闲时间有限，后续将不再对Issues中 “已经解答”、“已有解决方案” 的问题进行重复性的回答。
 
@@ -44,6 +44,7 @@ $ vim .env
 ```
 
 > **注意：** `.env` 文件中的变量 `CLASH_SECRET` 为自定义 Clash Secret，值为空时，脚本将自动生成随机字符串。
+> 如需使用其它架构，请将对应 Clash 二进制放入 `bin/` 并在 `.env` 中设置 `CLASH_BIN`，或命名为 `clash-linux-<arch>`（如 `clash-linux-riscv64`）。
 
 <br>
 
@@ -181,7 +182,13 @@ $ sudo systemctl stop clash-for-linux.service
 > 如需自定义运行用户，可在执行脚本前设置 `CLASH_SERVICE_USER`（可选 `CLASH_SERVICE_GROUP`）。
 > 默认使用 `clash` 用户运行服务，systemd 环境文件输出到 `temp/clash-for-linux.sh`。
 
-如果需要手动安装，可参考 `systemd/clash-for-linux.service` 模板并替换安装路径。
+如果需要手动安装，可参考 `systemd/clash-for-linux.service` 模板，并在 `/etc/default/clash-for-linux` 中设置 `CLASH_HOME`：
+
+```bash
+sudo cp systemd/clash-for-linux.env /etc/default/clash-for-linux
+sudo vim /etc/default/clash-for-linux
+```
+也可以创建 `/etc/default/clash-for-linux` 并设置 `CLASH_HOME`，模板会自动读取该路径。
 
 
 <br>
@@ -200,10 +207,11 @@ $ sudo systemctl stop clash-for-linux.service
 - `linux-arm64`
 - `linux-armv7`
 
-你也可以设置：
+自动下载默认使用 `https://github.com/tindy2013/subconverter/releases/latest/download/subconverter_{arch}.tar.gz`，
+如果需要自定义来源或关闭下载，可以设置：
 
 - `SUBCONVERTER_PATH`：指定自定义 `subconverter` 可执行文件路径。
-- `SUBCONVERTER_AUTO_DOWNLOAD=true`：启用自动下载（需 `curl`/`wget`）。
+- `SUBCONVERTER_AUTO_DOWNLOAD=false`：关闭自动下载（默认会尝试自动下载，需 `curl`/`wget`）。
 - `SUBCONVERTER_DOWNLOAD_URL_TEMPLATE`：下载模板，使用 `{arch}` 占位符，如：
 
 ```bash

--- a/scripts/resolve_subconverter.sh
+++ b/scripts/resolve_subconverter.sh
@@ -49,8 +49,11 @@ if [ -n "$Resolved_Arch" ]; then
 	try_subconverter_bin "${Subconverter_Dir}/${Resolved_Arch}/subconverter" && return 0
 fi
 
-if [ "${SUBCONVERTER_AUTO_DOWNLOAD:-false}" = "true" ] && [ -n "$Resolved_Arch" ]; then
-	Download_Template="${SUBCONVERTER_DOWNLOAD_URL_TEMPLATE:-}"
+Default_Template="https://github.com/tindy2013/subconverter/releases/latest/download/subconverter_{arch}.tar.gz"
+Auto_Download="${SUBCONVERTER_AUTO_DOWNLOAD:-auto}"
+
+if [ "$Auto_Download" != "false" ] && [ -n "$Resolved_Arch" ]; then
+	Download_Template="${SUBCONVERTER_DOWNLOAD_URL_TEMPLATE:-$Default_Template}"
 	if [ -z "$Download_Template" ]; then
 		echo -e "\033[33m[WARN] 未设置 SUBCONVERTER_DOWNLOAD_URL_TEMPLATE，跳过 subconverter 自动下载\033[0m"
 		return 0
@@ -79,4 +82,5 @@ if [ "${SUBCONVERTER_AUTO_DOWNLOAD:-false}" = "true" ] && [ -n "$Resolved_Arch" 
 			try_subconverter_bin "${Subconverter_Dir}/subconverter-${Resolved_Arch}" && return 0
 		fi
 	fi
+	echo -e "\033[33m[WARN] subconverter 自动下载失败，跳过订阅转换\033[0m"
 fi

--- a/systemd/clash-for-linux.env
+++ b/systemd/clash-for-linux.env
@@ -1,0 +1,5 @@
+CLASH_HOME=/opt/clash-for-linux
+# 可选：自定义 PID 文件路径
+# CLASH_PID_FILE=/opt/clash-for-linux/temp/clash.pid
+# 可选：自定义 Clash 二进制路径
+# CLASH_BIN=/opt/clash-for-linux/bin/clash-linux-amd64

--- a/systemd/clash-for-linux.service
+++ b/systemd/clash-for-linux.service
@@ -4,15 +4,16 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/opt/clash-for-linux
-ExecStart=/bin/bash /opt/clash-for-linux/start.sh
-ExecStop=/bin/bash /opt/clash-for-linux/shutdown.sh
+EnvironmentFile=-/etc/default/clash-for-linux
+Environment=CLASH_HOME=/opt/clash-for-linux
+ExecStart=/bin/bash -c 'exec /bin/bash "${CLASH_HOME}/start.sh"'
+ExecStop=/bin/bash -c 'exec /bin/bash "${CLASH_HOME}/shutdown.sh"'
 Restart=on-failure
 RestartSec=5
 User=clash
 Group=clash
-PIDFile=/opt/clash-for-linux/temp/clash.pid
-Environment=CLASH_ENV_FILE=/opt/clash-for-linux/temp/clash-for-linux.sh
+PIDFile=%E{CLASH_HOME}/temp/clash.pid
+Environment=CLASH_ENV_FILE=%E{CLASH_HOME}/temp/clash-for-linux.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Motivation
- Make the runtime more portable by supporting custom/extra CPU architectures and user-specified binary locations instead of hardcoding three binaries.
- Allow deployments to override the PID file and Clash binary via environment to support non-default layouts and low-privilege installs.
- Replace hardcoded paths in the systemd unit with a reusable environment file so manual installs don't require editing the unit file.
- Improve robustness of `subconverter` handling by providing a sane default download template and clearer opt-out behavior.

### Description
- Add `CLASH_PID_FILE` support and dynamic binary resolution in `start.sh` via `resolve_clash_arch` and `resolve_clash_bin`, and support `CLASH_BIN` to point to a custom executable.
- Update `start.sh` to pick the resolved binary and write PID to `PID_FILE` and emit clearer errors/instruction when no binary is found.
- Add `CLASH_BIN` example to `.env`, add `systemd/clash-for-linux.env` sample, and update `systemd/clash-for-linux.service` to read `CLASH_HOME` from `/etc/default/clash-for-linux` and use it in `ExecStart`/`ExecStop` and `PIDFile`/`Environment`.
- Change `scripts/resolve_subconverter.sh` to use a default download template (`https://github.com/tindy2013/subconverter/releases/latest/download/subconverter_{arch}.tar.gz`), use an `auto`/`false` semantics for `SUBCONVERTER_AUTO_DOWNLOAD`, and log a warning when automatic download fails; and update `README.md` to document `CLASH_BIN`, non-root usage notes, the systemd env file, and subconverter download behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69666bc7762483319fa17cbb9ce2b7b4)