### PR TITLE
Fix brace parsing bug in CLASH_DOWNLOAD_URL_TEMPLATE default value

### DIFF
--- a/scripts/resolve_clash.sh
+++ b/scripts/resolve_clash.sh
@@ -36,7 +36,8 @@ download_clash_bin() {
 		return 1
 	fi
 
-	download_url="${CLASH_DOWNLOAD_URL_TEMPLATE:-https://github.com/Dreamacro/clash/releases/latest/download/clash-{arch}.gz}"
+	local _default_url="https://github.com/Dreamacro/clash/releases/latest/download/clash-{arch}.gz"
+	download_url="${CLASH_DOWNLOAD_URL_TEMPLATE:-$_default_url}"
 	if [ -z "$download_url" ]; then
 		echo -e "\033[33m[WARN] 未设置 CLASH_DOWNLOAD_URL_TEMPLATE，跳过 Clash 内核自动下载\033[0m"
 		return 1


### PR DESCRIPTION
## Summary

- The `}` inside `{arch}` in the default URL string prematurely closes the bash `${...:-...}` parameter expansion, causing the download URL to be silently malformed
- Extracted the default URL into a separate variable to avoid the nested brace conflict

## Problem

In `scripts/resolve_clash.sh`, the original code:

```bash
download_url="${CLASH_DOWNLOAD_URL_TEMPLATE:-https://github.com/.../clash-{arch}.gz}"
```

Bash interprets the `}` in `{arch}` as the closing brace of the `${CLASH_DOWNLOAD_URL_TEMPLATE:-...}` expansion. This truncates the default to `https://github.com/.../clash-{arch` and appends `.gz}` as literal text, producing:

```
https://github.com/.../clash-{arch.gz}
```

The `{arch}` replacement on the next line then matches nothing, so the final URL still contains `{arch.gz}` — download silently fails.

## Fix

```bash
local _default_url="https://github.com/.../clash-{arch}.gz"
download_url="${CLASH_DOWNLOAD_URL_TEMPLATE:-$_default_url}"
```

By assigning the default to a separate variable first, `{arch}` is never inside a `${...:-...}` construct, so bash parses it correctly.

## Test plan

- [x] Verify `{arch}` is correctly replaced with `linux-amd64` / `linux-arm64` when `CLASH_DOWNLOAD_URL_TEMPLATE` is unset
- [x] Verify custom `CLASH_DOWNLOAD_URL_TEMPLATE` still works when set