### PR TITLE
Unset shell proxy on off, auto-restore persisted proxy, and rename status variable to system_proxy_text

### DIFF
--- a/scripts/core/alias.sh
+++ b/scripts/core/alias.sh
@@ -56,6 +56,12 @@ _clash_alias_proxy_show() {
   _clashctl_real proxy show 2>/dev/null || true
 }
 
+_clash_alias_unset_shell_proxy() {
+  unset \
+    http_proxy https_proxy HTTP_PROXY HTTPS_PROXY \
+    all_proxy ALL_PROXY no_proxy NO_PROXY
+}
+
 _clash_alias_status_next() {
   _clashctl_real status-next 2>/dev/null || echo "clashctl status"
 }
@@ -97,6 +103,7 @@ _clash_alias_run_on() {
 }
 
 _clash_alias_run_off() {
+  _clash_alias_unset_shell_proxy
   _clash_alias_proxy_off
   _clash_alias_set_persist_enabled "false"
   _clashctl_real off "$@" || return $?
@@ -104,6 +111,35 @@ _clash_alias_run_off() {
 }
 
 _clash_alias_auto_restore_proxy() {
+  local proxy_file http_url https_url all_url no_proxy
+
+  _clash_alias_persist_enabled || return 0
+
+  proxy_file="${SYSTEM_PROXY_ENV_FILE:-/etc/environment}"
+  [ -f "$proxy_file" ] || return 0
+  grep -Fq "# >>> clash-for-linux system proxy >>>" "$proxy_file" 2>/dev/null || return 0
+
+  http_url="$(sed -nE 's/^http_proxy="?([^"\r\n]+)"?$/\1/p' "$proxy_file" | tail -n 1)"
+  https_url="$(sed -nE 's/^https_proxy="?([^"\r\n]+)"?$/\1/p' "$proxy_file" | tail -n 1)"
+  all_url="$(sed -nE 's/^all_proxy="?([^"\r\n]+)"?$/\1/p' "$proxy_file" | tail -n 1)"
+  no_proxy="$(sed -nE 's/^NO_PROXY="?([^"\r\n]+)"?$/\1/p' "$proxy_file" | tail -n 1)"
+  [ -n "${no_proxy:-}" ] || no_proxy="$(sed -nE 's/^no_proxy="?([^"\r\n]+)"?$/\1/p' "$proxy_file" | tail -n 1)"
+
+  [ -n "${http_url:-}" ] || return 0
+  [ -n "${https_url:-}" ] || https_url="$http_url"
+  [ -n "${all_url:-}" ] || all_url="${http_url/http:\/\//socks5://}"
+  [ -n "${no_proxy:-}" ] || no_proxy="127.0.0.1,localhost,::1"
+
+  export http_proxy="$http_url"
+  export https_proxy="$https_url"
+  export HTTP_PROXY="$http_url"
+  export HTTPS_PROXY="$https_url"
+  export all_proxy="$all_url"
+  export ALL_PROXY="$all_url"
+  export no_proxy="$no_proxy"
+  export NO_PROXY="$no_proxy"
+
+  echo "♻️ 已恢复当前 shell 代理环境（来自持久化状态）"
   return 0
 }
 
@@ -125,6 +161,7 @@ clashctl() {
           _clash_alias_proxy_show
           ;;
         off)
+          _clash_alias_unset_shell_proxy
           _clash_alias_proxy_off
           _clash_alias_print_sep
           echo "🧹 系统代理已关闭"

--- a/scripts/core/clashctl.sh
+++ b/scripts/core/clashctl.sh
@@ -1723,7 +1723,7 @@ status_port_adjustment_brief() {
 
 print_status_summary_compact() {
   local profile mixed_port controller controller_lan controller_public
-  local running_text user_connectivity user_risk current_proxy_brief next_action shell_persist_text
+  local running_text user_connectivity user_risk current_proxy_brief next_action system_proxy_text
   local current_active dashboard_text dashboard_source_text dashboard_policy_text secret_text
   local tun_text
 
@@ -1748,9 +1748,9 @@ print_status_summary_compact() {
   current_proxy_brief="$(status_current_proxy_brief)"
   next_action="$(system_state_default_action 2>/dev/null || echo 'clashctl status')"
   if system_proxy_supported; then
-    shell_persist_text="$(system_proxy_status 2>/dev/null || echo off)"
+    system_proxy_text="$(system_proxy_status 2>/dev/null || echo off)"
   else
-    shell_persist_text="unsupported"
+    system_proxy_text="unsupported"
   fi
   if [ -f "$(runtime_dashboard_dir)/index.html" ]; then
     dashboard_text="已部署"
@@ -1791,7 +1791,7 @@ print_status_summary_compact() {
   echo "⚙️ 运行后端：$(status_runtime_backend_text)"
   echo "🧪 环境模式：$(status_container_mode_text)"
   echo "🧪 Tun 状态：${tun_text:-未知}"
-  echo "🧭 系统代理状态：${shell_persist_text}"
+  echo "🧭 系统代理状态：${system_proxy_text}"
   echo "🧩 Dashboard：${dashboard_text}（来源：${dashboard_source_text}）"
   echo "🧩 Dashboard 策略：${dashboard_policy_text}"
   echo "🔐 控制器密钥：${secret_text}"
@@ -1831,7 +1831,7 @@ print_status_summary_verbose() {
   local config_source config_source_time build_applied build_applied_time build_applied_reason
   local install_backend_text install_container_text install_verify_text port_adjustment_text
   local tun_enabled tun_effective tun_stack tun_container_text tun_kernel_text tun_verify_result tun_verify_reason tun_verify_time
-  local shell_persist_text dashboard_text dashboard_source_text dashboard_policy_text secret_text
+  local system_proxy_text dashboard_text dashboard_source_text dashboard_policy_text secret_text
 
   profile="$(show_active_profile 2>/dev/null || true)"
   [ -n "${profile:-}" ] || profile="default"
@@ -1894,9 +1894,9 @@ print_status_summary_verbose() {
   tun_verify_reason="$(status_tun_last_verify_reason 2>/dev/null || true)"
   tun_verify_time="$(status_tun_last_verify_time 2>/dev/null || true)"
   if system_proxy_supported; then
-    shell_persist_text="$(system_proxy_status 2>/dev/null || echo off)"
+    system_proxy_text="$(system_proxy_status 2>/dev/null || echo off)"
   else
-    shell_persist_text="unsupported"
+    system_proxy_text="unsupported"
   fi
   if [ -f "$(runtime_dashboard_dir)/index.html" ]; then
     dashboard_text="已部署"
@@ -1959,7 +1959,7 @@ print_status_summary_verbose() {
   echo "🧪 环境模式：${install_container_text:-unknown}"
   echo "🧩 安装验证：${install_verify_text:-unknown}"
   echo "🧭 端口裁决：${port_adjustment_text:-unknown}"
-  echo "🧭 系统代理状态：${shell_persist_text}"
+  echo "🧭 系统代理状态：${system_proxy_text}"
   echo "🧩 Dashboard：${dashboard_text}（来源：${dashboard_source_text}）"
   echo "🧩 Dashboard 策略：${dashboard_policy_text}"
   echo "🔐 控制器密钥：${secret_text}"
@@ -2814,7 +2814,7 @@ doctor_install_ports() {
 doctor_runtime_events() {
   local fallback_used fallback_time fallback_reason risk_level
   local config_source build_applied build_applied_time build_applied_reason
-  local shell_persist_text dashboard_status dashboard_source secret_status
+  local system_proxy_text dashboard_status dashboard_source secret_status
 
   doctor_print_title "运行事件检查"
 
@@ -2827,9 +2827,9 @@ doctor_runtime_events() {
   build_applied_time="$(status_runtime_build_applied_time 2>/dev/null || true)"
   build_applied_reason="$(status_runtime_build_applied_reason 2>/dev/null || true)"
   if system_proxy_supported; then
-    shell_persist_text="$(system_proxy_status 2>/dev/null || echo off)"
+    system_proxy_text="$(system_proxy_status 2>/dev/null || echo off)"
   else
-    shell_persist_text="unsupported"
+    system_proxy_text="unsupported"
   fi
   if [ -f "$(runtime_dashboard_dir)/index.html" ]; then
     dashboard_status="已部署"
@@ -2849,7 +2849,7 @@ doctor_runtime_events() {
 
   doctor_ok "当前风险等级：${risk_level:-unknown}"
   doctor_ok "当前配置来源：${config_source:-unknown}"
-  doctor_ok "系统代理状态：${shell_persist_text}"
+  doctor_ok "系统代理状态：${system_proxy_text}"
   doctor_ok "Dashboard 运行目录：${dashboard_status}（来源：${dashboard_source}）"
   doctor_ok ".env 控制器密钥：${secret_status}"
 
@@ -4850,6 +4850,7 @@ cmd_proxy() {
       echo
       echo "🧩 说明："
       echo "  on/off    开启或关闭系统代理（/etc/environment）"
+      echo "            仅修改系统代理接管状态，不输出 shell export 脚本"
       echo "  groups    查看可切换策略组"
       echo "  current   查看当前节点"
       echo "  nodes     查看某策略组候选节点"


### PR DESCRIPTION
### Motivation

- Ensure that when the CLI turns system proxy off it also clears proxy environment variables from the current shell to avoid leaking settings.
- Restore shell proxy variables from the persistent system proxy file when a shell starts and the system proxy was previously enabled.
- Improve clarity in status output by renaming the shell-persist variable to a clearer `system_proxy_text` across status and doctor outputs.

### Description

- Added `_clash_alias_unset_shell_proxy` which unsets `http_proxy`, `https_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, `all_proxy`, `ALL_PROXY`, `no_proxy`, and `NO_PROXY` in `scripts/core/alias.sh`.
- Call `_clash_alias_unset_shell_proxy` when running `clashctl proxy off` and when the shell alias `off` flow is executed to ensure the current shell environment is cleared.
- Added `_clash_alias_auto_restore_proxy` to read persisted proxy values from `SYSTEM_PROXY_ENV_FILE` (default `/etc/environment`) and export them into the current shell when persistence is enabled.
- Replaced `shell_persist_text` with `system_proxy_text` and updated related status and doctor printouts in `scripts/core/clashctl.sh` for consistent naming.
- Updated `clashctl proxy` help text to clarify that `on/off` only modifies the system proxy takeover state and does not emit shell `export` scripts.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b76afb488331884cb94863d49204)