### PR TITLE
fix(select): restrict clashctl select to manually selectable strategy groups #214

### DIFF
--- a/scripts/core/clashctl.sh
+++ b/scripts/core/clashctl.sh
@@ -6260,12 +6260,13 @@ proxy_pick_index() {
 
 proxy_pick_group_interactive() {
   local idx count group current
-  local -a groups ordered_groups
+  local -a groups=()
+  local -a ordered_groups=()
 
   while IFS= read -r group; do
     [ -n "${group:-}" ] || continue
     groups+=("$group")
-  done < <(proxy_group_list)
+  done < <(proxy_group_manual_list)
 
   for group in "节点选择" "自动选择"; do
     if printf '%s\n' "${groups[@]}" | grep -Fxq "$group"; then
@@ -6409,7 +6410,7 @@ cmd_sub() {
 proxy_select_interactive() {
   local group="${1:-}"
   local current idx count total_count node selected_node
-  local -a nodes
+  local -a nodes=()
 
   prepare
 
@@ -6424,6 +6425,8 @@ proxy_select_interactive() {
   if [ -z "${group:-}" ]; then
     ui_title "🚀 节点切换"
     group="$(proxy_pick_group_interactive)" || return 0
+  elif ! proxy_group_supports_manual_pick "$group"; then
+    die "该策略组不支持手动挑节点：$group"
   fi
 
   current="$(proxy_group_current "$group" 2>/dev/null || true)"

--- a/scripts/core/proxy.sh
+++ b/scripts/core/proxy.sh
@@ -293,6 +293,21 @@ proxy_group_is_selector() {
   esac
 }
 
+proxy_group_is_manual_selector() {
+  local type
+
+  type="$(proxy_group_type "$1")"
+
+  case "$type" in
+    Selector)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 proxy_group_list() {
   proxy_groups_json \
     | "$(yq_bin)" -p=json eval '
@@ -360,6 +375,32 @@ proxy_group_selectable_nodes() {
   done < <(proxy_group_nodes "$group")
 }
 
+proxy_group_supports_manual_pick() {
+  local group="$1"
+  local node
+
+  [ -n "${group:-}" ] || return 1
+  proxy_group_exists "$group" || return 1
+  proxy_group_is_manual_selector "$group" || return 1
+
+  while IFS= read -r node; do
+    [ -n "${node:-}" ] || continue
+    return 0
+  done < <(proxy_group_selectable_nodes "$group")
+
+  return 1
+}
+
+proxy_group_manual_list() {
+  local group
+
+  while IFS= read -r group; do
+    [ -n "${group:-}" ] || continue
+    proxy_group_supports_manual_pick "$group" || continue
+    echo "$group"
+  done < <(proxy_group_list)
+}
+
 proxy_group_select() {
   local group="$1"
   local node="$2"
@@ -371,7 +412,7 @@ proxy_group_select() {
   [ -n "${node:-}" ] || die "节点名称不能为空"
 
   proxy_group_exists "$group" || die "策略组不存在：$group"
-  proxy_group_is_selector "$group" || die "该策略组不支持手动切换：$group"
+  proxy_group_supports_manual_pick "$group" || die "该策略组不支持手动切换：$group"
 
   found=false
   while IFS= read -r available_node; do
@@ -510,7 +551,7 @@ ensure_default_proxy_group_relay_selected() {
     else
       switched="${group}|${current}|${relay}"
     fi
-  done < <(proxy_group_list)
+  done < <(proxy_group_manual_list)
 
   [ -n "${switched:-}" ] && echo "$switched"
 }


### PR DESCRIPTION
### Motivation
- `clashctl select` first-layer currently lists groups like `URLTest`/`Fallback`/`LoadBalance`/说明性组 which are not suitable for manual node picking and cause incorrect flows.  
- Selecting some of those groups could hit uninitialized-array / `nodes: unbound variable` failures in interactive flows.  
- Goal: make the main interactive path only present groups that truly support manual node selection, avoid entering node-pick for automatic groups, and keep existing descriptive-entry filtering (`proxy_group_selectable_nodes`).

### Description
- Modified files: `scripts/core/proxy.sh` and `scripts/core/clashctl.sh`.
- `scripts/core/proxy.sh`: added `proxy_group_is_manual_selector`, `proxy_group_supports_manual_pick`, and `proxy_group_manual_list`; changed `proxy_group_select` and `ensure_default_proxy_group_relay_selected` to use the new predicate/list so only true manual `Selector` groups with real candidates are considered for manual selection and auto-relay logic.  
- `scripts/core/clashctl.sh`: changed interactive group picker to read from `proxy_group_manual_list`, initialized interactive arrays explicitly (`groups=()`, `ordered_groups=()`, `nodes=()`), and added a guard so when a group is supplied it must pass `proxy_group_supports_manual_pick` (prevents automatic groups from entering node-picking).  
- Preserved `proxy_group_selectable_nodes` behavior (keeps filtering of descriptive/说明性 entries) and centralized the manual-selection definition to combine type + non-empty candidate checks.

### Testing
- Ran syntax checks: `bash -n scripts/core/proxy.sh && bash -n scripts/core/clashctl.sh` and they passed.  
- Verified no syntax errors after edits (`bash -n`) and that interactive arrays are explicitly initialized to prevent `unbound variable` under `set -u`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82248dadc83319c44ae0fc72e9567)