### PR TITLE
feat(install): resolve GEO assets via GitHub mirror proxy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,8 @@ ensure_required_commands
 init_layout
 ensure_dashboard_deploy_prerequisites
 
+resolve_geo_assets
+
 resolve_runtime_kernel
 resolve_yq
 resolve_subconverter

--- a/scripts/core/common.sh
+++ b/scripts/core/common.sh
@@ -419,7 +419,8 @@ copy_bundled_asset() {
   for candidate in \
     "$root/$category/$file" \
     "$root/$category/$version/$file" \
-    "$root/$file"; do
+    "$root/$file" \
+    "$RESOURCE_DIR/$category/$file"; do
     [ -s "$candidate" ] || continue
 
     mkdir -p "$(dirname "$out")"

--- a/scripts/core/runtime.sh
+++ b/scripts/core/runtime.sh
@@ -5,6 +5,35 @@ source "${PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}/scri
 # shellcheck source=scripts/core/config.sh
 source "${PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}/scripts/core/config.sh"
 
+GEO_ASSET_DOWNLOADS=(
+  "resources/geo/Country.mmdb https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb"
+  "resources/geo/geoip.metadb https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.metadb"
+  "resources/geo/GeoLite2-ASN.mmdb https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb"
+  "resources/geo/GeoIP.dat https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.dat"
+  "resources/geo/GeoSite.dat https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
+)
+
+resolve_geo_assets() {
+  case "${CLASH_PREDOWNLOAD_GEO:-true}" in
+    0|false|no|off|disable|disabled|FALSE|NO|OFF) return 0 ;;
+  esac
+
+  [ -n "${PROJECT_DIR:-}" ] || return 0
+
+  local item path url file target
+
+  for item in "${GEO_ASSET_DOWNLOADS[@]}"; do
+    path="${item%% *}"
+    url="${item#* }"
+    file="$(basename "$path")"
+    target="$RUNTIME_DIR/$file"
+
+    if ! copy_bundled_asset "geo" "latest" "$file" "$target" "$file"; then
+      download_file "$url" "$target" "$file"
+    fi
+  done
+}
+
 resolve_yq() {
   local arch version file url tmp_dir tmp_file
 


### PR DESCRIPTION
mihomo 默认从 raw.githubusercontent.com 下载 GEO 数据库
(https://github.com/MetaCubeX/mihomo/blob/Meta/config/config.go#L570-L575)， 在部分国内网络环境下无法获取，导致启动失败。

复现方式 **「在不可达github的时候可以复现」：**

```
  cat >/tmp/geosite-test.yaml <<'YAML'
  mixed-port: 7890
  allow-lan: false
  mode: rule
  log-level: debug
  proxies: []
  proxy-groups: []
  rules:
    - GEOSITE,cn,DIRECT YAML

  /root/clash/runtime/bin/mihomo -t -f /tmp/geosite-test.yaml -d /root/clash/runtime
```

报错：

```
  INFO Start initial configuration in progress
  INFO Geodata Loader mode: memconservative
  INFO Geosite Matcher implementation: succinct
  INFO Can't find GeoSite.dat, start download
  ERRO can't initial GeoSite: can't download GeoSite.dat:
       Get "https://release-assets.githubusercontent.com/...": context deadline exceeded
  ERRO rules[0] [GEOSITE,cn,DIRECT] error: can't download GeoSite.dat: context deadline exceeded
  configuration file /tmp/geosite-test.yaml test failed
```

新增 resolve_geo_assets 在安装阶段通过 GitHub 镜像池预下载全部 GEO 资产 到 RUNTIME_DIR，避免 mihomo 启动时因网络不通而失败。

资产列表对齐 mihomo GeoXUrl 默认值：
  Country.mmdb / geoip.metadb / GeoLite2-ASN.mmdb / GeoIP.dat / GeoSite.dat

- 复用 copy_bundled_asset 优先从 resources/geo/ 复制
- 本地不存在时通过 download_file 走 default_github_mirror_pool 镜像加速
- copy_bundled_asset 增加 $RESOURCE_DIR/$category/$file 搜索路径