### PR TITLE
fix(config): 规范化时剥离 subconverter 注入的 port/socks-port/redir-port，只保留 mixed-port

### DIFF
--- a/scripts/core/config.sh
+++ b/scripts/core/config.sh
@@ -839,6 +839,10 @@ normalize_runtime_config() {
     dns_listen_value="0.0.0.0:${dns_port_value}" \
     "$(yq_bin)" eval -i '
       .["mixed-port"] = (env(mixed_port) | tonumber) |
+      del(.port) |
+      del(.["socks-port"]) |
+      del(.["redir-port"]) |
+      del(.["tproxy-port"]) |
       .["external-controller"] = env(controller) |
       .secret = env(controller_secret_value) |
       .["external-ui"] = env(dashboard_dir_value) |

--- a/scripts/core/config.sh
+++ b/scripts/core/config.sh
@@ -839,10 +839,7 @@ normalize_runtime_config() {
     dns_listen_value="0.0.0.0:${dns_port_value}" \
     "$(yq_bin)" eval -i '
       .["mixed-port"] = (env(mixed_port) | tonumber) |
-      del(.port) |
-      del(.["socks-port"]) |
-      del(.["redir-port"]) |
-      del(.["tproxy-port"]) |
+      del(.port, .["socks-port"], .["redir-port"], .["tproxy-port"]) |
       .["external-controller"] = env(controller) |
       .secret = env(controller_secret_value) |
       .["external-ui"] = env(dashboard_dir_value) |


### PR DESCRIPTION
关联 #275。

## 改了什么

`normalize_runtime_config` 在写 `mixed-port` 的同时，删掉 subconverter 模板注入的 `port` / `socks-port` / `redir-port` / `tproxy-port`：

```yaml
.["mixed-port"] = (env(mixed_port) | tonumber) |
del(.port) |
del(.["socks-port"]) |
del(.["redir-port"]) |
del(.["tproxy-port"]) |
```

## 为什么

subconverter 的 base 模板写死了一套静态监听口（含 `socks-port: 7891`），这些口既不参与 `resolve_runtime_ports` 的避让，也不会被 `normalize_runtime_config` 改写。在共享服务器上 7890 被占时，避让会把 `mixed-port` 顶到 7891，正好和写死的 `socks-port: 7891` 撞车，mihomo 只绑上了 socks，http 口起不来，`clashon` 导出的 `http_proxy` 直接不可用（`curl: (56) Proxy CONNECT aborted`）。详细分析见 #275。

项目自带的 `config/template.yaml` 本来就只有 `mixed-port`，这几个静态口是历史遗留，删掉它们让最终配置回到单口设计。

## 验证

打补丁前（7890 被占，避让到 7891）：

```
$ grep -E 'mixed-port|socks-port|^port:|redir-port' runtime/config.yaml
port: 7890
socks-port: 7891
redir-port: 7892
mixed-port: 7891     # 与 socks-port 撞车
$ curl -x http://127.0.0.1:7891 https://example.com
curl: (56) Proxy CONNECT aborted
```

打补丁并 `clashctl config regen` 后：

```
$ grep -E 'mixed-port|socks-port|^port:|redir-port' runtime/config.yaml
mixed-port: 7890
$ curl -x http://127.0.0.1:7890 https://example.com   # http 307 正常
```

mihomo 日志确认单口正常工作：`Mixed(http+socks) proxy listening at: [::]:7890`。

改动只动了 `scripts/core/config.sh` 一处，对未触发避让的普通安装没有影响（本来就没这些静态口）。

Made with [Cursor](https://cursor.com)