### PR TITLE
完善订阅节点识别与 Zsh 代理环境支持

### DIFF
--- a/scripts/core/alias.sh
+++ b/scripts/core/alias.sh
@@ -38,6 +38,12 @@ _clashctl_real_on_target() {
 
 _clash_alias_project_dir() {
   local self_dir
+
+  if [ -n "${CLASH_FOR_LINUX_PROJECT_DIR:-}" ]; then
+    echo "$CLASH_FOR_LINUX_PROJECT_DIR"
+    return 0
+  fi
+
   self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   echo "$self_dir"
 }
@@ -56,10 +62,17 @@ _clash_alias_yq_bin() {
 
 _clash_alias_env_value() {
   local key="$1"
-  local env_file
+  local env_file value
 
-  if [ -n "${!key:-}" ]; then
-    printf '%s' "${!key}"
+  case "$key" in
+    ""|*[!A-Za-z0-9_]*)
+      return 0
+      ;;
+  esac
+
+  eval "value=\${$key:-}"
+  if [ -n "${value:-}" ]; then
+    printf '%s' "$value"
     return 0
   fi
 

--- a/scripts/core/common.sh
+++ b/scripts/core/common.sh
@@ -2614,10 +2614,11 @@ install_shell_alias_entry() {
 cat > "$profile_file" <<EOF
 #!/usr/bin/env bash
 # clash-for-linux shell entry
+export CLASH_FOR_LINUX_PROJECT_DIR="$PROJECT_DIR"
 export PATH="$(command_install_dir):\$PATH"
 
-if [ -n "\${BASH_VERSION:-}" ] && [ -z "\${CLASH_FOR_LINUX_SHELL_LOADED:-}" ]; then
-  CLASH_FOR_LINUX_SHELL_LOADED="1"
+if [ -z "\${CLASH_FOR_LINUX_SHELL_LOADED:-}" ] && { [ -n "\${BASH_VERSION:-}" ] || [ -n "\${ZSH_VERSION:-}" ]; }; then
+  export CLASH_FOR_LINUX_SHELL_LOADED="1"
   source "$alias_file"
 fi
 

--- a/scripts/core/config.sh
+++ b/scripts/core/config.sh
@@ -483,7 +483,7 @@ local_subscription_share_links_to_subconverter_url() {
       sub(/[[:space:]]+$/, "")
     }
     $0 == "" || $0 ~ /^#/ { next }
-    $0 ~ /^(vmess|vless|trojan|tuic):\/\// {
+    $0 ~ /^(vmess|vless|trojan|tuic|hysteria2|hy2|anytls):\/\// {
       if (out != "") {
         out = out "|"
       }
@@ -577,7 +577,7 @@ local_subscription_convert_url_from_url() {
   fi
 
   rm -f "$decoded_file" 2>/dev/null || true
-  die "本地订阅不是 Clash YAML，且无法识别为 Base64 或 vmess/vless/trojan/tuic 分享链接：$local_path"
+  die "本地订阅不是 Clash YAML，且无法识别为 Base64 或 vmess/vless/trojan/tuic/hysteria2/hy2/anytls 分享链接：$local_path"
 }
 
 download_candidate_probe() {
@@ -721,7 +721,15 @@ download_subscription_yaml() {
 subscription_cache_identity() {
   local url="$1"
   local fmt="${2:-clash}"
-  printf '%s|%s' "$fmt" "$url"
+  local ua=""
+
+  case "$fmt" in
+    clash|convert)
+      ua="$(subconverter_subscription_user_agent)"
+      ;;
+  esac
+
+  printf '%s|%s|%s' "$fmt" "$url" "$ua"
 }
 
 subscription_cache_key() {
@@ -3311,7 +3319,7 @@ subscription_yaml_has_no_nodes() {
 }
 
 subconverter_default_subscription_user_agent() {
-  echo "clash.meta/1.18.0 clash/1.18.0 subconverter/0.9.0"
+  echo "clash-verge/v2.2.3"
 }
 
 subconverter_subscription_user_agent() {


### PR DESCRIPTION
## 添加内容

- 增加 Hysteria2 / AnyTLS 订阅节点识别支持。
- 支持本地订阅中的 `hysteria2://`、`hy2://`、`anytls://` 链接。
- 调整订阅请求 User-Agent，让订阅源可以返回更多兼容节点。
- 优化订阅缓存区分逻辑，避免不同 User-Agent 复用同一份缓存。
- 补充 Zsh 环境下的 `clashon` 支持，使代理变量可以正确写入 Zsh 会话。