### PR TITLE
Feature/node delay rule wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - 🚀 **自动识别系统架构**：自动下载并使用对应 Clash 内核
 - 🧪 **端口自动检测与分配**：避免冲突
 - 🔄 **多订阅管理**：可以保存多个订阅，通过 `clashctl use` 切换当前主订阅。
-- 💫 **节点选择**：使用编号交互选择策略组和节点。
+- 💫 **节点选择**：使用编号交互选择策略组和节点，并显示历史延迟；可按 `r` 并发刷新当前策略组测速。
 - 🌐 **Tun 模式**：用于透明代理接管场景（需root方式安装）。
 - 🧠 **Mixin 机制**：可按需追加/覆盖 Clash 配置
 - 👤 **不同权限**：兼容 `root` 与普通用户环境。
@@ -74,6 +74,7 @@ bash install.sh
   clashctl tun       🧪 Tun 模式管理（需root方式安装）
   clashctl boot      🚦 开机代理接管管理
   clashctl mixin     🧩 Mixin 配置管理
+  clashctl rule      📜 规则管理
   clashctl relay     🔗 多跳节点管理
   clashctl sub       🧩 订阅高级管理（启用 / 禁用 / 重命名 / 删除）
   clashctl upgrade   🚀 升级当前或指定内核
@@ -395,6 +396,8 @@ clashctl mixin
 clashctl mixin edit
 clashctl mixin raw
 clashctl mixin runtime
+clashctl rule
+clashctl rule test example.com
 ```
 
 Mixin 是运行配置补丁，不是订阅管理。它优先通过 `runtime/mixin.yaml`（兼容读取 `config/mixin.yaml`）对当前 active 订阅生成的运行配置执行：
@@ -402,6 +405,9 @@ Mixin 是运行配置补丁，不是订阅管理。它优先通过 `runtime/mixi
 - `override`
 - `prepend`
 - `append`
+- `remove`
+
+规则可通过 `clashctl rule` 查看当前运行规则，并交互添加或删除规则；`clashctl rule test example.com` 可静态判断网站会命中哪条明文规则。
 
 示例：
 
@@ -421,6 +427,10 @@ append:
   proxy-groups: []
   rules:
     - MATCH,节点选择
+
+remove:
+  rules:
+    - DOMAIN,old.example,DIRECT
 ```
 
 编辑后执行：

--- a/scripts/core/alias.sh
+++ b/scripts/core/alias.sh
@@ -38,6 +38,12 @@ _clashctl_real_on_target() {
 
 _clash_alias_project_dir() {
   local self_dir
+
+  if [ -n "${CLASH_FOR_LINUX_PROJECT_DIR:-}" ]; then
+    echo "$CLASH_FOR_LINUX_PROJECT_DIR"
+    return 0
+  fi
+
   self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   echo "$self_dir"
 }
@@ -56,10 +62,17 @@ _clash_alias_yq_bin() {
 
 _clash_alias_env_value() {
   local key="$1"
-  local env_file
+  local env_file value
 
-  if [ -n "${!key:-}" ]; then
-    printf '%s' "${!key}"
+  case "$key" in
+    ""|*[!A-Za-z0-9_]*)
+      return 0
+      ;;
+  esac
+
+  eval "value=\${$key:-}"
+  if [ -n "${value:-}" ]; then
+    printf '%s' "$value"
     return 0
   fi
 

--- a/scripts/core/clashctl.sh
+++ b/scripts/core/clashctl.sh
@@ -33,6 +33,7 @@ Usage:
   config                         🧩 配置编译管理
   config kernel mihomo|clash     🧩 切换指定内核
   mixin                          🧩 Mixin 配置管理
+  rule                           📜 规则管理
   relay                          🔗 多跳节点管理
   lan                            🏠 局域网代理管理
   
@@ -77,6 +78,7 @@ Usage:
 
   clashctl relay add 多跳-示例 节点A 节点B --domain example.com
   clashctl relay list
+  clashctl rule
 
 💡 Notes:
   当前编译链固定为 active-only
@@ -4219,7 +4221,8 @@ mixin_config_is_empty() {
       (((.prepend.rules // []) | length) == 0) and
       (((.append.proxies // []) | length) == 0) and
       (((.append["proxy-groups"] // []) | length) == 0) and
-      (((.append.rules // []) | length) == 0)
+      (((.append.rules // []) | length) == 0) and
+      (((.remove.rules // []) | length) == 0)
     ' "$file" 2>/dev/null | head -n 1 || true)"
     [ "$noop" = "true" ] && return 0
   fi
@@ -4270,11 +4273,16 @@ append:
   rules:
     - MATCH,节点选择
 
+remove:
+  rules:
+    - DOMAIN,old.example,DIRECT
+
 说明：
   override 会覆盖同名字段
   override.secret 会被忽略，控制器密钥只从 .env 的 CLASH_CONTROLLER_SECRET 读取
   prepend 会把数组内容放到原始订阅前面
   append 会把数组内容放到原始订阅后面
+  remove 会从最终规则中删除匹配项
 EOF
 }
 
@@ -4383,35 +4391,7 @@ cmd_mixin() {
 }
 
 ensure_relay_mixin_file() {
-  local file
-  ensure_config_files
-  file="$(mixin_config_file)"
-
-  [ -s "$file" ] || cat > "$file" <<'EOF'
-override: {}
-prepend:
-  proxies: []
-  proxy-groups: []
-  rules: []
-append:
-  proxies: []
-  proxy-groups: []
-  rules: []
-EOF
-
-  "$(yq_bin)" eval -i '
-    .override = (.override // {}) |
-    .prepend = (.prepend // {}) |
-    .prepend.proxies = (.prepend.proxies // []) |
-    .prepend["proxy-groups"] = (.prepend["proxy-groups"] // []) |
-    .prepend.rules = (.prepend.rules // []) |
-    .append = (.append // {}) |
-    .append.proxies = (.append.proxies // []) |
-    .append["proxy-groups"] = (.append["proxy-groups"] // []) |
-    .append.rules = (.append.rules // [])
-  ' "$file"
-
-  echo "$file"
+  ensure_mixin_arrays
 }
 
 relay_apply_mixin_change() {
@@ -4590,6 +4570,373 @@ cmd_relay() {
       die_usage "未知的 relay 子命令：$1" "clashctl relay help"
       ;;
   esac
+}
+
+rule_prompt_position() {
+  local idx
+
+  echo "📜 请选择规则位置：" >&2
+  echo "  1) 前置规则（推荐）" >&2
+  echo "  2) 后置规则" >&2
+  echo "  q) 退出" >&2
+  echo >&2
+
+  idx="$(proxy_pick_index 2 1)" || return 1
+  case "$idx" in
+    1) echo "prepend" ;;
+    2) echo "append" ;;
+  esac
+}
+
+rule_prompt_type() {
+  local idx type
+  local -a types=(DOMAIN-SUFFIX DOMAIN-KEYWORD DOMAIN IP-CIDR GEOIP MATCH)
+
+  echo "📜 请选择规则类型：" >&2
+  idx=1
+  for type in "${types[@]}"; do
+    printf '  %s) %s\n' "$idx" "$type" >&2
+    idx=$((idx + 1))
+  done
+  echo "  q) 退出" >&2
+  echo >&2
+
+  idx="$(proxy_pick_index "${#types[@]}" 1)" || return 1
+  echo "${types[$((idx - 1))]}"
+}
+
+rule_prompt_content() {
+  local type="$1"
+  local input
+
+  [ "$type" = "MATCH" ] && return 0
+
+  while true; do
+    printf "请输入规则内容：" >&2
+    IFS= read -r input || return 1
+    input="$(add_trim_input "$input")"
+
+    [ -n "${input:-}" ] || {
+      echo "🚨 规则内容不能为空" >&2
+      continue
+    }
+    case "$input" in
+      *,*)
+        echo "🚨 规则内容不能包含英文逗号" >&2
+        continue
+        ;;
+    esac
+
+    echo "$input"
+    return 0
+  done
+}
+
+rule_policy_candidates() {
+  printf '%s\n' DIRECT REJECT
+  [ -s "$RUNTIME_DIR/config.yaml" ] || return 0
+  "$(yq_bin)" eval '(.["proxy-groups"] // [])[].name // ""' "$RUNTIME_DIR/config.yaml" 2>/dev/null
+}
+
+rule_prompt_policy() {
+  local idx candidate
+  local -a policies=()
+
+  while IFS= read -r candidate; do
+    [ -n "${candidate:-}" ] || continue
+    printf '%s\n' "${policies[@]}" | grep -Fxq "$candidate" 2>/dev/null && continue
+    policies+=("$candidate")
+  done < <(rule_policy_candidates)
+
+  echo "📜 请选择代理策略：" >&2
+  idx=1
+  for candidate in "${policies[@]}"; do
+    printf '  %s) %s\n' "$idx" "$candidate" >&2
+    idx=$((idx + 1))
+  done
+  echo "  q) 退出" >&2
+  echo >&2
+
+  idx="$(proxy_pick_index "${#policies[@]}" 1)" || return 1
+  echo "${policies[$((idx - 1))]}"
+}
+
+rule_build_line() {
+  local type="$1"
+  local content="$2"
+  local policy="$3"
+
+  case "$type" in
+    DOMAIN-SUFFIX|DOMAIN-KEYWORD|DOMAIN|IP-CIDR|GEOIP|MATCH) ;;
+    *) die "不支持的规则类型：$type" ;;
+  esac
+  case "$policy" in
+    ""|*,*) die "代理策略名称不能为空且不能包含英文逗号" ;;
+  esac
+
+  if [ "$type" = "MATCH" ]; then
+    echo "MATCH,$policy"
+  else
+    echo "$type,$content,$policy"
+  fi
+}
+
+rule_add_interactive() {
+  local position type content policy rule file
+
+  ui_title "📜 添加规则"
+  position="$(rule_prompt_position)" || return 0
+  type="$(rule_prompt_type)" || return 0
+  content="$(rule_prompt_content "$type")" || return 0
+  policy="$(rule_prompt_policy)" || return 0
+  rule="$(rule_build_line "$type" "$content" "$policy")"
+
+  file="$(mixin_add_rule "$position" "$rule")"
+
+  ui_title "📜 规则已写入"
+  ui_kv "🔧" "配置文件" "$file"
+  ui_kv "📜" "规则" "$rule"
+
+  echo
+  echo "ℹ️ 正在重新生成配置 ..."
+  regenerate_config
+  apply_runtime_change_after_config_mutation
+  ui_next "clashctl mixin runtime"
+  ui_blank
+}
+
+rule_read_key() {
+  local key rest="" next result input_fd=0 tty_opened="false"
+
+  if [ -t 0 ] && { exec 3</dev/tty; } 2>/dev/null; then
+    input_fd=3
+    tty_opened="true"
+  fi
+
+  IFS= read -rsn1 key <&"$input_fd" || {
+    [ "$tty_opened" = "true" ] && exec 3<&-
+    return 1
+  }
+  case "$key" in
+    $'\033')
+      while IFS= read -rsn1 -t 0.5 next <&"$input_fd"; do
+        rest="${rest}${next}"
+        case "$next" in
+          A|B|C|D|~) break ;;
+        esac
+        [ "${#rest}" -lt 8 ] || break
+      done
+      case "$rest" in
+        *A) result="up" ;;
+        *B) result="down" ;;
+        *C) result="right" ;;
+        *D) result="left" ;;
+        *) result="escape" ;;
+      esac
+      ;;
+    *)
+      result="$key"
+      ;;
+  esac
+
+  [ "$tty_opened" = "true" ] && exec 3<&-
+  echo "$result"
+}
+
+rule_print_menu() {
+  local selected="$1"
+  local page_start="$2"
+  local idx position_label marker end page page_count page_size=10
+
+  [ -t 1 ] && printf '\033[H\033[J'
+  ui_title "📜 当前规则"
+
+  if [ "$rule_count" -eq 0 ]; then
+    echo "  暂无规则"
+  else
+    end=$((page_start + page_size))
+    [ "$end" -gt "$rule_count" ] && end="$rule_count"
+    page=$((page_start / page_size + 1))
+    page_count=$(((rule_count + page_size - 1) / page_size))
+
+    echo "  页 $page/$page_count   显示 $((page_start + 1))-$end / $rule_count   当前 $((selected + 1))"
+    echo "  ----------------------------------------"
+
+    idx="$page_start"
+    while [ "$idx" -lt "$end" ]; do
+      marker=" "
+      [ "$idx" -eq "$selected" ] && marker=">"
+      case "${rule_positions[$idx]}" in
+        prepend) position_label="自定义前置" ;;
+        append) position_label="自定义后置" ;;
+        *) position_label="运行" ;;
+      esac
+      printf '  %s %s [%s] %s\n' "$marker" "$((idx + 1))" "$position_label" "${rule_values[$idx]}"
+      idx=$((idx + 1))
+    done
+    echo "  ----------------------------------------"
+  fi
+
+  echo
+  echo "  ↑/↓ 选择   ←/→ 翻页   a 添加   d 删除   q 退出"
+  echo
+}
+
+rule_confirm_delete() {
+  local rule="$1"
+  local answer
+
+  echo >&2
+  echo "确认删除这条规则？" >&2
+  echo "  $rule" >&2
+  printf "按 y 删除，其他键取消: " >&2
+  answer="$(rule_read_key)" || return 1
+  echo >&2
+
+  [ "$answer" = "y" ] || [ "$answer" = "Y" ]
+}
+
+cmd_rule_test() {
+  local target host match index rule policy
+
+  [ "$#" -eq 1 ] || die_usage "rule test 需要一个网站或域名" "clashctl rule test example.com"
+  [ -s "$RUNTIME_DIR/config.yaml" ] || die_state "运行配置不存在" "clashctl config regen"
+
+  target="$1"
+  host="$(rule_test_target_host "$target")" || die_usage "规则测试目标不合法：$target" "clashctl rule test example.com"
+
+  ui_title "📜 规则测试"
+  ui_kv "🌐" "目标" "$host"
+
+  if match="$(rule_match_for_target "$host")"; then
+    IFS=$'\t' read -r index rule policy <<< "$match"
+    ui_kv "🔢" "规则序号" "$((index + 1))"
+    ui_kv "📜" "命中规则" "$rule"
+    ui_kv "🎯" "代理策略" "${policy:-<unknown>}"
+  else
+    ui_warn "没有命中可静态判断的规则"
+    ui_info "当前仅判断 DOMAIN / DOMAIN-SUFFIX / DOMAIN-KEYWORD / MATCH"
+    ui_blank
+    return 1
+  fi
+
+  ui_blank
+}
+
+cmd_rule() {
+  local selected=0 page_start=0 page_size=10 page_end key removed_rule file reload="true"
+  local -a rule_positions=()
+  local -a rule_indexes=()
+  local -a rule_values=()
+  local rule_count=0 position index rule
+
+  prepare
+  [ -x "$(yq_bin)" ] || die_state "依赖未就绪：缺少 yq（$(yq_bin)）" "请先执行 bash install.sh"
+
+  case "${1:-}" in
+    test)
+      shift || true
+      cmd_rule_test "$@"
+      return 0
+      ;;
+    "")
+      ;;
+    help|-h|--help)
+      ui_title "📜 规则管理"
+      echo "📜 用法："
+      echo "  clashctl rule"
+      echo "  clashctl rule test <网站或域名>"
+      echo
+      echo "说明："
+      echo "  列出当前运行配置规则；自定义规则来自 runtime/mixin.yaml"
+      echo "  ↑/↓ 选择规则，←/→ 翻页，a 添加规则，d 删除规则，q 退出"
+      echo "  test 静态判断网站会命中哪条明文规则"
+      return 0
+      ;;
+    *)
+      die_usage "未知的 rule 子命令：$1" "clashctl rule help"
+      ;;
+  esac
+
+  while true; do
+    if [ "$reload" = "true" ]; then
+      rule_positions=()
+      rule_indexes=()
+      rule_values=()
+      while IFS=$'\t' read -r position index rule; do
+        [ -n "${rule:-}" ] || continue
+        rule_positions+=("$position")
+        rule_indexes+=("$index")
+        rule_values+=("$rule")
+      done < <(current_rules_list)
+
+      rule_count="${#rule_values[@]}"
+      if [ "$rule_count" -gt 0 ]; then
+        [ "$selected" -ge "$rule_count" ] && selected=$((rule_count - 1))
+        [ "$page_start" -ge "$rule_count" ] && page_start=$(((rule_count - 1) / page_size * page_size))
+        [ "$selected" -lt "$page_start" ] && selected="$page_start"
+        [ "$selected" -ge $((page_start + page_size)) ] && selected="$page_start"
+      else
+        selected=0
+        page_start=0
+      fi
+      reload="false"
+    fi
+
+    rule_print_menu "$selected" "$page_start"
+    key="$(rule_read_key)" || return 0
+
+    case "$key" in
+      q|Q)
+        return 0
+        ;;
+      a|A)
+        rule_add_interactive
+        reload="true"
+        ;;
+      up)
+        [ "$rule_count" -gt 0 ] && [ "$selected" -gt "$page_start" ] && selected=$((selected - 1))
+        ;;
+      down)
+        page_end=$((page_start + page_size))
+        [ "$page_end" -gt "$rule_count" ] && page_end="$rule_count"
+        [ "$rule_count" -gt 0 ] && [ "$selected" -lt $((page_end - 1)) ] && selected=$((selected + 1))
+        ;;
+      left)
+        if [ "$page_start" -gt 0 ]; then
+          page_start=$((page_start - page_size))
+          selected="$page_start"
+        fi
+        ;;
+      right)
+        if [ "$rule_count" -gt 0 ] && [ $((page_start + page_size)) -lt "$rule_count" ]; then
+          page_start=$((page_start + page_size))
+          selected="$page_start"
+        fi
+        ;;
+      d|D)
+        [ "$rule_count" -gt 0 ] || continue
+        removed_rule="${rule_values[$selected]}"
+        rule_confirm_delete "$removed_rule" || continue
+        case "${rule_positions[$selected]:-}" in
+          prepend|append)
+            file="$(mixin_remove_rule_at "${rule_positions[$selected]}" "${rule_indexes[$selected]}")"
+            ;;
+          *)
+            file="$(mixin_remove_runtime_rule "$removed_rule")"
+            ;;
+        esac
+        ui_title "📜 规则已删除"
+        ui_kv "🔧" "配置文件" "$file"
+        ui_kv "📜" "规则" "$removed_rule"
+        echo
+        echo "ℹ️ 正在重新生成配置 ..."
+        regenerate_config
+        apply_runtime_change_after_config_mutation
+        reload="true"
+        ;;
+    esac
+  done
 }
 
 runtime_config_exists() {
@@ -6873,11 +7220,14 @@ cmd_proxy_nodes() {
 
 proxy_pick_index() {
   local count="$1"
+  local default="${2:-}"
   local input
 
   while true; do
     printf "> " >&2
     IFS= read -r input || return 1
+    input="$(add_trim_input "$input")"
+    [ -n "${input:-}" ] || [ -z "$default" ] || input="$default"
 
     case "${input:-}" in
       q|Q)
@@ -6892,6 +7242,49 @@ proxy_pick_index() {
 
     echo "🚨 请输入 1-$count 之间的编号，或输入 q 退出" >&2
   done
+}
+
+proxy_pick_node_index() {
+  local count="$1"
+  local input
+
+  while true; do
+    printf "> " >&2
+    IFS= read -r input || return 1
+    input="$(add_trim_input "$input")"
+
+    case "${input:-}" in
+      q|Q)
+        return 1
+        ;;
+      r|R)
+        echo "refresh"
+        return 0
+        ;;
+    esac
+
+    if printf '%s' "$input" | grep -Eq '^[0-9]+$' && [ "$input" -ge 1 ] && [ "$input" -le "$count" ]; then
+      echo "$input"
+      return 0
+    fi
+
+    echo "🚨 请输入 1-$count 之间的编号，输入 r 刷新测速，或输入 q 退出" >&2
+  done
+}
+
+proxy_print_node_choice_line() {
+  local idx="$1"
+  local node="$2"
+  local current="$3"
+  local delay="$4"
+  local delay_label
+
+  delay_label="$(proxy_delay_label "${delay:-0}")"
+  if [ "$node" = "$current" ]; then
+    printf '  %s) 🚀 %s %s [当前]\n' "$idx" "$node" "$delay_label"
+  else
+    printf '  %s) 🚀 %s %s\n' "$idx" "$node" "$delay_label"
+  fi
 }
 
 proxy_pick_group_interactive() {
@@ -7560,7 +7953,8 @@ cmd_proxy_current() {
 
 cmd_proxy_nodes() {
   local group="$1"
-  local current node found="false"
+  local current node delay delay_label found="false"
+  local -A delays=()
 
   prepare
   [ -n "${group:-}" ] || die "请使用 clashctl select 切换节点"
@@ -7580,13 +7974,19 @@ cmd_proxy_nodes() {
   ui_kv "🚀" "当前节点" "${current:-<unknown>}"
   ui_blank
 
+  while IFS=$'\t' read -r node delay; do
+    [ -n "${node:-}" ] || continue
+    delays["$node"]="$delay"
+  done < <(proxy_group_nodes_delay_map "$group")
+
   while IFS= read -r node; do
     [ -n "${node:-}" ] || continue
     found="true"
+    delay_label="$(proxy_delay_label "${delays[$node]:-0}")"
     if [ "$node" = "$current" ]; then
-      printf '  * 🚀 %s\n' "$node"
+      printf '  * 🚀 %s %s\n' "$node" "$delay_label"
     else
-      printf '    🚀 %s\n' "$node"
+      printf '    🚀 %s %s\n' "$node" "$delay_label"
     fi
   done < <(proxy_group_selectable_nodes "$group")
 
@@ -7647,9 +8047,11 @@ proxy_pick_group_for_select() {
 
 proxy_select_interactive_guarded() {
   local group="${1:-}"
-  local current idx count total_count node selected_node
+  local current idx count total_count node selected_node delay line_index line_up prompt_gap=4 redraw="true"
   local choose_group="false"
   local -a nodes=()
+  local -A delays=()
+  local -A node_indexes=()
 
   prepare
 
@@ -7675,10 +8077,17 @@ proxy_select_interactive_guarded() {
 
     current="$(proxy_group_current_display "$group" 2>/dev/null || true)"
     nodes=()
+    delays=()
+    node_indexes=()
     while IFS= read -r node; do
       [ -n "${node:-}" ] || continue
+      node_indexes["$node"]="${#nodes[@]}"
       nodes+=("$node")
     done < <(proxy_group_selectable_nodes "$group")
+    while IFS=$'\t' read -r node delay; do
+      [ -n "${node:-}" ] || continue
+      delays["$node"]="$delay"
+    done < <(proxy_group_nodes_delay_map "$group")
 
     count="${#nodes[@]}"
     if [ "$count" -le 0 ]; then
@@ -7694,36 +8103,61 @@ proxy_select_interactive_guarded() {
     fi
 
     total_count="$(select_total_node_count 2>/dev/null || true)"
+    redraw="true"
+    prompt_gap=4
 
-    echo
-    echo "📦 当前策略组：$group"
-    echo "🚀 当前节点：${current:-<unknown>}"
-    echo "📦 当前策略组候选数：$count"
-    [ -n "${total_count:-}" ] && echo "🔢 全部节点总数：$total_count"
-    echo "ℹ️ 以下仅显示当前策略组可切换节点"
-    echo
-    echo "🚀 请选择节点："
+    while true; do
+      if [ "$redraw" = "true" ]; then
+        echo
+        echo "📦 当前策略组：$group"
+        echo "🚀 当前节点：${current:-<unknown>}"
+        echo "📦 当前策略组候选数：$count"
+        [ -n "${total_count:-}" ] && echo "🔢 全部节点总数：$total_count"
+        echo "ℹ️ 以下仅显示当前策略组可切换节点；[-] 表示暂无延迟记录"
+        echo
+        echo "🚀 请选择节点："
 
-    idx=1
-    for node in "${nodes[@]}"; do
-      if [ "$node" = "$current" ]; then
-        printf '  %s) 🚀 %s [当前]\n' "$idx" "$node"
-      else
-        printf '  %s) 🚀 %s\n' "$idx" "$node"
+        idx=1
+        for node in "${nodes[@]}"; do
+          proxy_print_node_choice_line "$idx" "$node" "$current" "${delays[$node]:-0}"
+          idx=$((idx + 1))
+        done
+
+        echo "  r) 刷新延迟"
+        echo "  q) 退出"
+        echo
+        redraw="false"
       fi
-      idx=$((idx + 1))
+
+      idx="$(proxy_pick_node_index "$count")" || return 0
+      if [ "$idx" = "refresh" ]; then
+        echo "ℹ️ 正在刷新当前策略组节点延迟 ..."
+        while IFS=$'\t' read -r node delay; do
+          [ -n "${node:-}" ] || continue
+          delays["$node"]="${delay:-0}"
+          line_index="${node_indexes[$node]:-}"
+          [ -n "${line_index:-}" ] || continue
+          if [ -t 1 ]; then
+            line_up=$((count - line_index + prompt_gap + 1))
+            printf '\033[s\033[%sA\r\033[2K' "$line_up"
+            proxy_print_node_choice_line "$((line_index + 1))" "$node" "$current" "${delay:-0}"
+            printf '\033[u'
+          else
+            proxy_print_node_choice_line "$((line_index + 1))" "$node" "$current" "${delay:-0}"
+          fi
+        done < <(proxy_nodes_test_delay_map 8 "${nodes[@]}")
+        echo "✓ 刷新完成"
+        prompt_gap=$((prompt_gap + 3))
+        continue
+      fi
+
+      selected_node="${nodes[$((idx - 1))]}"
+      proxy_node_is_selectable_candidate "$selected_node" || die "节点不是可切换节点：$selected_node"
+
+      proxy_group_select "$group" "$selected_node"
+      print_select_feedback "$group"
+      return 0
     done
-
-    echo "  q) 退出"
-    echo
-
-    idx="$(proxy_pick_index "$count")" || return 0
-    selected_node="${nodes[$((idx - 1))]}"
-    proxy_node_is_selectable_candidate "$selected_node" || die "节点不是可切换节点：$selected_node"
-
-    proxy_group_select "$group" "$selected_node"
-    print_select_feedback "$group"
-    return 0
   done
 }
 
@@ -7750,6 +8184,7 @@ case "$cmd" in
   config)         cmd_config "$@" ;;
   lan)            cmd_lan "$@" ;;
   mixin)          cmd_mixin "$@" ;;
+  rule)           cmd_rule "$@" ;;
   relay)          cmd_relay "$@" ;;
   profile)        cmd_profile "$@" ;;
   sub)            cmd_sub "$@" ;;

--- a/scripts/core/common.sh
+++ b/scripts/core/common.sh
@@ -2614,10 +2614,11 @@ install_shell_alias_entry() {
 cat > "$profile_file" <<EOF
 #!/usr/bin/env bash
 # clash-for-linux shell entry
+export CLASH_FOR_LINUX_PROJECT_DIR="$PROJECT_DIR"
 export PATH="$(command_install_dir):\$PATH"
 
-if [ -n "\${BASH_VERSION:-}" ] && [ -z "\${CLASH_FOR_LINUX_SHELL_LOADED:-}" ]; then
-  CLASH_FOR_LINUX_SHELL_LOADED="1"
+if [ -z "\${CLASH_FOR_LINUX_SHELL_LOADED:-}" ] && { [ -n "\${BASH_VERSION:-}" ] || [ -n "\${ZSH_VERSION:-}" ]; }; then
+  export CLASH_FOR_LINUX_SHELL_LOADED="1"
   source "$alias_file"
 fi
 

--- a/scripts/core/completion.sh
+++ b/scripts/core/completion.sh
@@ -216,6 +216,17 @@ _clash_for_linux_complete_relay() {
   esac
 }
 
+_clash_for_linux_complete_rule() {
+  local cur="$1"
+  local rel_index="$2"
+
+  COMPREPLY=()
+
+  if [ "$rel_index" -eq 1 ]; then
+    _clash_for_linux_add_matches "$cur" test help -h --help
+  fi
+}
+
 _clash_for_linux_complete_sub() {
   local cur="$1"
   local rel_index="$2"
@@ -316,7 +327,7 @@ _clash_for_linux_complete_top_level() {
   _clash_for_linux_add_matches "$cur" \
     add use ls health select on off status status-next \
     boot log logs doctor ui secret tun dev config lan mixin \
-    relay profile sub proxy upgrade update completion help \
+    rule relay profile sub proxy upgrade update completion help \
     -h --help
 }
 
@@ -381,6 +392,7 @@ _clash_for_linux_complete_command() {
     config) _clash_for_linux_complete_config "$cur" "$rel_index" "$arg1" ;;
     lan) _clash_for_linux_complete_lan "$cur" "$rel_index" ;;
     mixin) _clash_for_linux_complete_mixin "$cur" "$rel_index" ;;
+    rule) _clash_for_linux_complete_rule "$cur" "$rel_index" ;;
     relay) _clash_for_linux_complete_relay "$cur" "$rel_index" "$arg1" ;;
     sub) _clash_for_linux_complete_sub "$cur" "$rel_index" "$arg1" ;;
     tun) _clash_for_linux_complete_tun "$cur" "$rel_index" ;;

--- a/scripts/core/config.sh
+++ b/scripts/core/config.sh
@@ -2161,6 +2161,8 @@ append:
   proxies: []
   proxy-groups: []
   rules: []
+remove:
+  rules: []
 EOF
 }
 
@@ -2225,6 +2227,191 @@ ensure_mixin_file() {
   fi
 }
 
+ensure_mixin_arrays() {
+  local file
+  ensure_mixin_file
+  file="$(mixin_file)"
+
+  "$(yq_bin)" eval -i '
+    .override = (.override // {}) |
+    .prepend = (.prepend // {}) |
+    .prepend.proxies = (.prepend.proxies // []) |
+    .prepend["proxy-groups"] = (.prepend["proxy-groups"] // []) |
+    .prepend.rules = (.prepend.rules // []) |
+    .append = (.append // {}) |
+    .append.proxies = (.append.proxies // []) |
+    .append["proxy-groups"] = (.append["proxy-groups"] // []) |
+    .append.rules = (.append.rules // []) |
+    .remove = (.remove // {}) |
+    .remove.rules = (.remove.rules // [])
+  ' "$file"
+
+  echo "$file"
+}
+
+mixin_add_rule() {
+  local position="$1"
+  local rule="$2"
+  local file
+
+  case "$position" in
+    prepend|append) ;;
+    *) die "规则位置只允许 prepend / append" ;;
+  esac
+  [ -n "${rule:-}" ] || die "规则不能为空"
+
+  file="$(ensure_mixin_arrays)"
+  if [ "$position" = "prepend" ]; then
+    MIXIN_RULE="$rule" "$(yq_bin)" eval -i '
+      .remove.rules = ((.remove.rules // []) | map(select(. != strenv(MIXIN_RULE)))) |
+      .append.rules = ((.append.rules // []) | map(select(. != strenv(MIXIN_RULE)))) |
+      .prepend.rules = ([strenv(MIXIN_RULE)] + ((.prepend.rules // []) | map(select(. != strenv(MIXIN_RULE)))))
+    ' "$file"
+  else
+    MIXIN_RULE="$rule" "$(yq_bin)" eval -i '
+      .remove.rules = ((.remove.rules // []) | map(select(. != strenv(MIXIN_RULE)))) |
+      .prepend.rules = ((.prepend.rules // []) | map(select(. != strenv(MIXIN_RULE)))) |
+      .append.rules = (((.append.rules // []) | map(select(. != strenv(MIXIN_RULE)))) + [strenv(MIXIN_RULE)])
+    ' "$file"
+  fi
+
+  echo "$file"
+}
+
+mixin_rules_list() {
+  local file
+  file="$(ensure_mixin_arrays)"
+
+  "$(yq_bin)" eval '(.prepend.rules // [])[]' "$file" 2>/dev/null \
+    | awk -v pos="prepend" '{print pos "\t" NR-1 "\t" $0}'
+  "$(yq_bin)" eval '(.append.rules // [])[]' "$file" 2>/dev/null \
+    | awk -v pos="append" '{print pos "\t" NR-1 "\t" $0}'
+}
+
+runtime_rules_list() {
+  local file="$RUNTIME_DIR/config.yaml"
+
+  [ -s "$file" ] || return 0
+  "$(yq_bin)" eval '(.rules // [])[]' "$file" 2>/dev/null \
+    | awk '{print NR-1 "\t" $0}'
+}
+
+rule_test_target_host() {
+  local target="$1"
+  local host
+
+  target="$(printf '%s' "$target" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [ -n "${target:-}" ] || return 1
+  case "$target" in
+    *://*) target="${target#*://}" ;;
+  esac
+  target="${target%%[/?#]*}"
+  target="${target##*@}"
+
+  case "$target" in
+    \[*\]*)
+      host="${target#\[}"
+      host="${host%%\]*}"
+      ;;
+    *)
+      host="${target%%:*}"
+      ;;
+  esac
+
+  host="${host%.}"
+  host="$(printf '%s' "$host" | tr 'A-Z' 'a-z')"
+  [ -n "${host:-}" ] || return 1
+  case "$host" in
+    *[!a-z0-9._-]*) return 1 ;;
+  esac
+
+  printf '%s\n' "$host"
+}
+
+rule_match_for_target() {
+  local host="$1"
+
+  host="$(rule_test_target_host "$host")" || return 1
+  runtime_rules_list | awk -F '\t' -v host="$host" '
+    {
+      rule = $2
+      split(rule, field, ",")
+      type = field[1]
+      content = tolower(field[2])
+      policy = (type == "MATCH") ? field[2] : field[3]
+      suffix_match = type == "DOMAIN-SUFFIX" && (host == content || (length(host) > length(content) && substr(host, length(host) - length(content), 1) == "." && substr(host, length(host) - length(content) + 1) == content))
+
+      if (!found && ((type == "DOMAIN" && host == content) || suffix_match || (type == "DOMAIN-KEYWORD" && index(host, content) > 0) || type == "MATCH")) {
+        print $1 "\t" rule "\t" policy
+        found = 1
+      }
+    }
+    END { if (!found) exit 1 }
+  '
+}
+
+current_rules_list() {
+  local file="$RUNTIME_DIR/config.yaml"
+
+  if [ ! -s "$file" ]; then
+    mixin_rules_list
+    return 0
+  fi
+
+  awk -F '\t' '
+    FILENAME == ARGV[1] {
+      if (!($3 in pos)) {
+        pos[$3] = $1
+        idx[$3] = $2
+      }
+      next
+    }
+    {
+      rule = $2
+      if (rule in pos) {
+        print pos[rule] "\t" idx[rule] "\t" rule
+      } else {
+        print "runtime\t-\t" rule
+      }
+    }
+  ' <(mixin_rules_list) <(runtime_rules_list)
+}
+
+mixin_remove_rule_at() {
+  local position="$1"
+  local index="$2"
+  local file
+
+  case "$position" in
+    prepend|append) ;;
+    *) die "规则位置只允许 prepend / append" ;;
+  esac
+  case "$index" in
+    ""|*[!0-9]*) die "规则序号必须是数字" ;;
+  esac
+
+  file="$(ensure_mixin_arrays)"
+  if [ "$position" = "prepend" ]; then
+    "$(yq_bin)" eval -i "del(.prepend.rules[$index])" "$file"
+  else
+    "$(yq_bin)" eval -i "del(.append.rules[$index])" "$file"
+  fi
+
+  echo "$file"
+}
+
+mixin_remove_runtime_rule() {
+  local rule="$1"
+  local file
+
+  [ -n "${rule:-}" ] || die "规则不能为空"
+
+  file="$(ensure_mixin_arrays)"
+  MIXIN_RULE="$rule" "$(yq_bin)" eval -i '.remove.rules = ((.remove.rules // []) + [strenv(MIXIN_RULE)] | unique)' "$file"
+
+  echo "$file"
+}
+
 apply_mixin_override() {
   local runtime_file="$1"
   local mixin_file_path
@@ -2268,6 +2455,20 @@ apply_mixin_append_arrays() {
     | .proxies = (((.proxies // []) + ($mixin.append.proxies // [])) | unique_by(.name))
     | .["proxy-groups"] = (((.["proxy-groups"] // []) + ($mixin.append["proxy-groups"] // [])) | unique_by(.name))
     | .rules = (((.rules // []) + ($mixin.append.rules // [])) | unique)
+  ' "$runtime_file"
+}
+
+apply_mixin_remove_arrays() {
+  local runtime_file="$1"
+  local mixin_file_path
+  mixin_file_path="$(mixin_read_file)"
+
+  [ -s "$runtime_file" ] || die "运行配置不存在：$runtime_file"
+  [ -f "$mixin_file_path" ] || return 0
+
+  RUNTIME_FILE="$runtime_file" MIXIN_FILE="$mixin_file_path" "$(yq_bin)" eval -i '
+    (load(strenv(MIXIN_FILE)) // {}) as $mixin
+    | .rules = ((.rules // []) - ($mixin.remove.rules // []))
   ' "$runtime_file"
 }
 
@@ -2315,6 +2516,17 @@ apply_runtime_mixin() {
     return 1
   fi
   rm -f "$(config_tmp_dir)/mixin-append.err" 2>/dev/null || true
+
+  build_debug "mixin: remove"
+  if ! apply_mixin_remove_arrays "$runtime_file" 2>"$(config_tmp_dir)/mixin-remove.err"; then
+    write_compile_error_with_detail \
+      "其他运行配置 YAML 解析失败：$(display_config_path "$runtime_file")" \
+      "$runtime_file" \
+      "mixin remove: $(cat "$(config_tmp_dir)/mixin-remove.err" 2>/dev/null || true)"
+    rm -f "$(config_tmp_dir)/mixin-remove.err" 2>/dev/null || true
+    return 1
+  fi
+  rm -f "$(config_tmp_dir)/mixin-remove.err" 2>/dev/null || true
 }
 
 show_subscription() {

--- a/scripts/core/config.sh
+++ b/scripts/core/config.sh
@@ -483,7 +483,7 @@ local_subscription_share_links_to_subconverter_url() {
       sub(/[[:space:]]+$/, "")
     }
     $0 == "" || $0 ~ /^#/ { next }
-    $0 ~ /^(vmess|vless|trojan|tuic):\/\// {
+    $0 ~ /^(vmess|vless|trojan|tuic|hysteria2|hy2|anytls):\/\// {
       if (out != "") {
         out = out "|"
       }
@@ -577,7 +577,7 @@ local_subscription_convert_url_from_url() {
   fi
 
   rm -f "$decoded_file" 2>/dev/null || true
-  die "本地订阅不是 Clash YAML，且无法识别为 Base64 或 vmess/vless/trojan/tuic 分享链接：$local_path"
+  die "本地订阅不是 Clash YAML，且无法识别为 Base64 或 vmess/vless/trojan/tuic/hysteria2/hy2/anytls 分享链接：$local_path"
 }
 
 download_candidate_probe() {
@@ -721,7 +721,15 @@ download_subscription_yaml() {
 subscription_cache_identity() {
   local url="$1"
   local fmt="${2:-clash}"
-  printf '%s|%s' "$fmt" "$url"
+  local ua=""
+
+  case "$fmt" in
+    clash|convert)
+      ua="$(subconverter_subscription_user_agent)"
+      ;;
+  esac
+
+  printf '%s|%s|%s' "$fmt" "$url" "$ua"
 }
 
 subscription_cache_key() {
@@ -3311,7 +3319,7 @@ subscription_yaml_has_no_nodes() {
 }
 
 subconverter_default_subscription_user_agent() {
-  echo "clash.meta/1.18.0 clash/1.18.0 subconverter/0.9.0"
+  echo "clash-verge/v2.2.3"
 }
 
 subconverter_subscription_user_agent() {

--- a/scripts/core/proxy.sh
+++ b/scripts/core/proxy.sh
@@ -771,6 +771,51 @@ proxy_node_test_delay() {
     | head -n 1
 }
 
+proxy_nodes_test_delay_map() {
+  local limit="$1"
+  local node delay running=0
+
+  shift || true
+  case "$limit" in
+    ""|0|*[!0-9]*) limit=8 ;;
+  esac
+
+  for node in "$@"; do
+    (
+      delay="$(proxy_node_test_delay "$node" 2>/dev/null || echo 0)"
+      printf '%s\t%s\n' "$node" "${delay:-0}"
+    ) &
+    running=$((running + 1))
+    if [ "$running" -ge "$limit" ]; then
+      wait
+      running=0
+    fi
+  done
+  wait
+}
+
+proxy_delay_label() {
+  local delay="${1:-0}"
+  local color
+
+  case "$delay" in
+    ""|0|null|*[!0-9]*)
+      printf '[-]'
+      return 0
+      ;;
+  esac
+
+  if [ "$delay" -lt 100 ]; then
+    color=32
+  elif [ "$delay" -le 300 ]; then
+    color=33
+  else
+    color=31
+  fi
+
+  printf '\033[%sm[%sms]\033[0m' "$color" "$delay"
+}
+
 proxy_group_nodes_delay_map() {
   local group="$1"
 

--- a/scripts/dev/check-rule-mixin.sh
+++ b/scripts/dev/check-rule-mixin.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/runtime/bin" "$tmp_dir/runtime/tmp" "$tmp_dir/config" "$tmp_dir/logs"
+cp "$PROJECT_DIR/runtime/bin/yq" "$tmp_dir/runtime/bin/yq"
+
+export PROJECT_DIR
+export RUNTIME_DIR="$tmp_dir/runtime"
+export BIN_DIR="$tmp_dir/runtime/bin"
+export LOG_DIR="$tmp_dir/logs"
+export CONFIG_DIR="$tmp_dir/config"
+
+# shellcheck source=scripts/core/config.sh
+source "$PROJECT_DIR/scripts/core/config.sh"
+# shellcheck source=scripts/core/proxy.sh
+source "$PROJECT_DIR/scripts/core/proxy.sh"
+
+assert_eq() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [ "$actual" != "$expected" ]; then
+    echo "not ok - $name: got '$actual', expected '$expected'" >&2
+    return 1
+  fi
+
+  echo "ok - $name"
+}
+
+mixin_add_rule prepend "DOMAIN-SUFFIX,example.com,DIRECT" >/dev/null
+mixin_add_rule prepend "DOMAIN-SUFFIX,example.com,DIRECT" >/dev/null
+mixin_add_rule append "MATCH,节点选择" >/dev/null
+
+mixin_yaml="$(mixin_file)"
+cat > "$RUNTIME_DIR/config.yaml" <<'YAML'
+rules:
+  - DOMAIN-SUFFIX,example.com,DIRECT
+  - DOMAIN,base.example,节点选择
+  - MATCH,节点选择
+YAML
+
+assert_eq "normalizes rule test target" "api.example.com" "$(rule_test_target_host "https://API.EXAMPLE.COM:443/path?q=1")"
+assert_eq "matches suffix rule" "$(printf '0\tDOMAIN-SUFFIX,example.com,DIRECT\tDIRECT')" "$(rule_match_for_target "api.example.com")"
+assert_eq "matches exact rule" "$(printf '1\tDOMAIN,base.example,节点选择\t节点选择')" "$(rule_match_for_target "base.example")"
+assert_eq "matches fallback rule" "$(printf '2\tMATCH,节点选择\t节点选择')" "$(rule_match_for_target "other.test")"
+
+assert_eq "deduplicates prepend rules" "1" "$("$BIN_DIR/yq" eval '(.prepend.rules // []) | length' "$mixin_yaml")"
+assert_eq "writes prepend rule" "DOMAIN-SUFFIX,example.com,DIRECT" "$("$BIN_DIR/yq" eval '.prepend.rules[0]' "$mixin_yaml")"
+assert_eq "writes append rule" "MATCH,节点选择" "$("$BIN_DIR/yq" eval '.append.rules[0]' "$mixin_yaml")"
+assert_eq "lists rules" "2" "$(mixin_rules_list | wc -l | tr -d ' ')"
+assert_eq "lists runtime rules" "3" "$(runtime_rules_list | wc -l | tr -d ' ')"
+assert_eq "marks runtime custom rules" "$(printf 'prepend\t0\tDOMAIN-SUFFIX,example.com,DIRECT\nruntime\t-\tDOMAIN,base.example,节点选择\nappend\t0\tMATCH,节点选择')" "$(current_rules_list)"
+
+"$BIN_DIR/yq" eval -i '.prepend.rules = [] | .append.rules = []' "$mixin_yaml"
+assert_eq "lists runtime rules without custom rules" "3" "$(current_rules_list | wc -l | tr -d ' ')"
+
+mixin_remove_rule_at append 0 >/dev/null
+assert_eq "removes append rule" "0" "$("$BIN_DIR/yq" eval '(.append.rules // []) | length' "$mixin_yaml")"
+
+cat > "$RUNTIME_DIR/config.yaml" <<'YAML'
+rules:
+  - DOMAIN-SUFFIX,example.com,DIRECT
+  - DOMAIN,base.example,节点选择
+  - MATCH,节点选择
+YAML
+mixin_remove_runtime_rule "DOMAIN,base.example,节点选择" >/dev/null
+assert_eq "writes removed runtime rule" "DOMAIN,base.example,节点选择" "$("$BIN_DIR/yq" eval '.remove.rules[0]' "$mixin_yaml")"
+apply_mixin_remove_arrays "$RUNTIME_DIR/config.yaml"
+assert_eq "filters removed runtime rule" "0" "$(runtime_rules_list | awk -F '\t' '$2 == "DOMAIN,base.example,节点选择" { count++ } END { print count + 0 }')"
+mixin_add_rule append "DOMAIN,base.example,节点选择" >/dev/null
+assert_eq "adding removed rule clears remove marker" "0" "$("$BIN_DIR/yq" eval '(.remove.rules // []) | length' "$mixin_yaml")"
+mixin_add_rule prepend "DOMAIN,base.example,节点选择" >/dev/null
+assert_eq "moves rule to prepend" "DOMAIN,base.example,节点选择" "$("$BIN_DIR/yq" eval '.prepend.rules[0]' "$mixin_yaml")"
+assert_eq "removes moved rule from append" "0" "$("$BIN_DIR/yq" eval '(.append.rules // []) | length' "$mixin_yaml")"
+
+assert_eq "green delay label" "$(printf '\033[32m[80ms]\033[0m')" "$(proxy_delay_label 80)"
+assert_eq "yellow delay label" "$(printf '\033[33m[180ms]\033[0m')" "$(proxy_delay_label 180)"
+assert_eq "red delay label" "$(printf '\033[31m[450ms]\033[0m')" "$(proxy_delay_label 450)"
+assert_eq "empty delay label" "[-]" "$(proxy_delay_label 0)"
+
+proxy_node_test_delay() {
+  case "$1" in
+    node-a) echo 10 ;;
+    node-b) echo 20 ;;
+    *) echo 0 ;;
+  esac
+}
+assert_eq "parallel delay map" "$(printf 'node-a\t10\nnode-b\t20')" "$(proxy_nodes_test_delay_map 2 node-a node-b | sort)"


### PR DESCRIPTION
## 概要
- 添加了增加 Hysteria2 / AnyTLS 订阅节点识别支持。（在pr #283 基础上继续做）
- 在节点选择列表中显示节点延迟。
- 新增交互式规则管理入口。
- 支持测试域名会命中哪条规则和策略。

## 变更内容

- 在 `clashctl select` 中显示节点最近延迟，未测速时显示 `[-]`。
- 支持按 `r` 刷新当前策略组节点延迟。
- 新增 `clashctl rule`：
  - 查看当前运行规则
  - 添加前置 / 后置规则
  - 删除规则前确认
  - 测试域名命中的规则和代理策略
- 自定义规则写入 `runtime/mixin.yaml`：
  - 添加规则写入 `prepend.rules` 或 `append.rules`
  - 删除自定义规则时从 mixin 中移除
  - 删除订阅自带规则时写入 `remove.rules`，重新生成配置时过滤
- 更新命令补全，让终端可以补全新的 `clashctl rule` 入口。
- 更新 README，补充规则管理和规则测试的基础用法。

## 展示
### 节点延迟测速
```bash
clashctl select
```
在最终节点选择的时候会显示所有节点延迟，`r`可以刷新延迟
<img width="494" height="429" alt="image" src="https://github.com/user-attachments/assets/f90756b2-611e-4a2e-86a4-eaaf07b5bf35" />

### 修改规则
```bash
clashctl rule 
```
上下选择修改查看规则，左右翻页，`a`添加新规则，`d`删除规则
<img width="649" height="343" alt="image" src="https://github.com/user-attachments/assets/6133513d-8a8e-48cc-b0f5-f624368517b5" />
按下`a`后，可以选择规则类型，内容，策略
<img width="459" height="439" alt="image" src="https://github.com/user-attachments/assets/421b6bc0-f969-4cd4-b5b3-6a9bf9674374" />

