### PR TITLE
Fix systemd boot runtime supervision

### DIFF
--- a/scripts/core/clashctl.sh
+++ b/scripts/core/clashctl.sh
@@ -7382,6 +7382,11 @@ cmd_start_direct() {
   start_runtime
 }
 
+cmd_run_direct() {
+  prepare
+  run_runtime_foreground
+}
+
 cmd_stop_direct() {
   prepare
   stop_runtime
@@ -7801,6 +7806,7 @@ case "$cmd" in
   upgrade)        cmd_upgrade "$@" ;;
   update)         cmd_update "$@" ;;
   completion)     cmd_completion "$@" ;;
+  run-direct)     cmd_run_direct "$@" ;;
   start-direct)   cmd_start_direct "$@" ;;
   stop-direct)    cmd_stop_direct "$@" ;;
   restart-direct) cmd_restart_direct "$@" ;;

--- a/scripts/core/runtime.sh
+++ b/scripts/core/runtime.sh
@@ -533,9 +533,10 @@ wait_runtime_controller_ready() {
   return 1
 }
 
-start_runtime() {
+prepare_runtime_start() {
   local config_file="$RUNTIME_DIR/config.yaml"
 
+  mkdir -p "$RUNTIME_DIR" "$LOG_DIR"
   resolve_runtime_kernel
   if [ -s "$config_file" ]; then
     ensure_mihomo_geodata_ready "$config_file" || die "因 GEOIP 依赖未就绪，当前配置无法启动：$config_file"
@@ -543,6 +544,12 @@ start_runtime() {
 
   ensure_runtime_config_ready
   ensure_mihomo_geodata_ready "$config_file" || die "因 GEOIP 依赖未就绪，当前配置无法启动：$config_file"
+}
+
+start_runtime() {
+  local config_file="$RUNTIME_DIR/config.yaml"
+
+  prepare_runtime_start
 
   if [ -f "$RUNTIME_DIR/mihomo.pid" ]; then
     local old_pid
@@ -573,6 +580,18 @@ start_runtime() {
   fi
 
   success "$(runtime_kernel_name) 已启动：pid=$(cat "$RUNTIME_DIR/mihomo.pid")"
+}
+
+run_runtime_foreground() {
+  local config_file="$RUNTIME_DIR/config.yaml"
+
+  prepare_runtime_start
+
+  rm -f "$RUNTIME_DIR/mihomo.pid" 2>/dev/null || true
+  echo "$$" > "$RUNTIME_DIR/mihomo.pid"
+
+  exec "$(runtime_kernel_bin)" -f "$config_file" -d "$RUNTIME_DIR" \
+    >> "$LOG_DIR/mihomo.out.log" 2>&1
 }
 
 stop_runtime() {

--- a/scripts/core/update.sh
+++ b/scripts/core/update.sh
@@ -83,9 +83,10 @@ refresh_installed_entry_files() {
   # shellcheck source=scripts/core/common.sh
   source "$PROJECT_DIR/scripts/core/common.sh"
 
-  info "正在刷新命令入口与 shell profile"
+  info "正在刷新命令入口、shell profile 与运行后端入口"
   install_clashctl_entry
   install_shell_alias_entry
+  install_runtime_entry
 }
 
 remove_mihomo_binary() {

--- a/scripts/dev/check-systemd-run-direct-units.sh
+++ b/scripts/dev/check-systemd-run-direct-units.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+assert_contains() {
+  local name="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "not ok - $name: missing '$pattern' in $file" >&2
+    return 1
+  fi
+
+  echo "ok - $name"
+}
+
+assert_not_contains() {
+  local name="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if grep -Fq "$pattern" "$file"; then
+    echo "not ok - $name: unexpected '$pattern' in $file" >&2
+    return 1
+  fi
+
+  echo "ok - $name"
+}
+
+assert_contains "system service uses simple foreground process" "$PROJECT_DIR/scripts/init/systemd.sh" "Type=simple"
+assert_contains "system service starts run-direct" "$PROJECT_DIR/scripts/init/systemd.sh" "ExecStart=/usr/local/bin/clashctl run-direct"
+assert_not_contains "system service no longer uses forking" "$PROJECT_DIR/scripts/init/systemd.sh" "Type=forking"
+assert_not_contains "system service no longer relies on PIDFile" "$PROJECT_DIR/scripts/init/systemd.sh" "PIDFile="
+
+assert_contains "user service uses simple foreground process" "$PROJECT_DIR/scripts/init/systemd-user.sh" "Type=simple"
+assert_contains "user service starts run-direct" "$PROJECT_DIR/scripts/init/systemd-user.sh" "clashctl run-direct"
+assert_not_contains "user service no longer uses forking" "$PROJECT_DIR/scripts/init/systemd-user.sh" "Type=forking"
+assert_not_contains "user service no longer relies on PIDFile" "$PROJECT_DIR/scripts/init/systemd-user.sh" "PIDFile="

--- a/scripts/init/systemd-user.sh
+++ b/scripts/init/systemd-user.sh
@@ -14,11 +14,9 @@ Description=clash-for-linux (user)
 After=default.target
 
 [Service]
-Type=forking
-ExecStart=$home_dir/.local/bin/clashctl start-direct
-ExecStop=$home_dir/.local/bin/clashctl stop-direct
-ExecReload=$home_dir/.local/bin/clashctl restart-direct
-PIDFile=$RUNTIME_DIR/mihomo.pid
+Type=simple
+ExecStart=$home_dir/.local/bin/clashctl run-direct
+ExecStopPost=/bin/rm -f $RUNTIME_DIR/mihomo.pid
 WorkingDirectory=$PROJECT_DIR
 Restart=on-failure
 RestartSec=3
@@ -107,8 +105,16 @@ systemd_user_service_status_text() {
 }
 
 systemd_user_service_logs() {
-  journalctl --user -u "$(service_unit_name)" -n 200 --no-pager 2>/dev/null || {
-    echo "未获取到用户级 systemd 服务日志"
-    return 0
-  }
+  echo "== systemctl --user status =="
+  systemctl --user status "$(service_unit_name)" --no-pager -l 2>/dev/null || echo "未获取到用户级 systemd 服务状态"
+  echo
+  echo "== journalctl --user =="
+  journalctl --user -u "$(service_unit_name)" -n 200 --no-pager 2>/dev/null || echo "未获取到用户级 systemd journal 日志"
+  echo
+  echo "== mihomo log =="
+  if [ -f "$LOG_DIR/mihomo.out.log" ]; then
+    tail -n 200 "$LOG_DIR/mihomo.out.log"
+  else
+    echo "mihomo 日志文件不存在：$LOG_DIR/mihomo.out.log"
+  fi
 }

--- a/scripts/init/systemd.sh
+++ b/scripts/init/systemd.sh
@@ -11,11 +11,9 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=forking
-ExecStart=/usr/local/bin/clashctl start-direct
-ExecStop=/usr/local/bin/clashctl stop-direct
-ExecReload=/usr/local/bin/clashctl restart-direct
-PIDFile=$RUNTIME_DIR/mihomo.pid
+Type=simple
+ExecStart=/usr/local/bin/clashctl run-direct
+ExecStopPost=/bin/rm -f $RUNTIME_DIR/mihomo.pid
 WorkingDirectory=$PROJECT_DIR
 Restart=on-failure
 RestartSec=3
@@ -103,8 +101,16 @@ systemd_service_status_text() {
 }
 
 systemd_service_logs() {
-  journalctl -u "$(service_unit_name)" -n 200 --no-pager 2>/dev/null || {
-    echo "未获取到 systemd 服务日志"
-    return 0
-  }
+  echo "== systemctl status =="
+  systemctl status "$(service_unit_name)" --no-pager -l 2>/dev/null || echo "未获取到 systemd 服务状态"
+  echo
+  echo "== journalctl =="
+  journalctl -u "$(service_unit_name)" -n 200 --no-pager 2>/dev/null || echo "未获取到 systemd journal 日志"
+  echo
+  echo "== mihomo log =="
+  if [ -f "$LOG_DIR/mihomo.out.log" ]; then
+    tail -n 200 "$LOG_DIR/mihomo.out.log"
+  else
+    echo "mihomo 日志文件不存在：$LOG_DIR/mihomo.out.log"
+  fi
 }


### PR DESCRIPTION
## Summary
- Change systemd and systemd-user units to `Type=simple` and run the kernel in the foreground through `clashctl run-direct`.
- Keep the existing background `start-direct` path for script/manual compatibility.
- Refresh the runtime backend entry during `clashctl update` so existing installs receive the new unit template.
- Expand `clashctl logs service` output with systemctl status, journal, and mihomo file log fallback.
- Add a regression check that systemd units no longer use `Type=forking`/`PIDFile`.

## Validation
- `bash -n install.sh uninstall.sh scripts/core/*.sh scripts/init/*.sh scripts/dev/*.sh`
- `for f in scripts/dev/*.sh; do bash "$f"; done`

## Issue
Addresses #287.