### PR TITLE
Speed up Clash status with TUN enabled

### DIFF
--- a/scripts/core/clashctl.sh
+++ b/scripts/core/clashctl.sh
@@ -621,6 +621,19 @@ status_tun_effective_status() {
     return 0
   fi
 
+  if [ "$(runtime_config_tun_enabled 2>/dev/null || echo false)" = "true" ] \
+    && status_is_running 2>/dev/null \
+    && proxy_controller_reachable 2>/dev/null \
+    && [ "$(runtime_config_tun_auto_route 2>/dev/null || echo false)" = "true" ] \
+    && tun_has_policy_routing_evidence 2>/dev/null; then
+    if tun_log_tun_source_line >/dev/null 2>&1; then
+      echo "effective"
+    else
+      echo "likely-effective"
+    fi
+    return 0
+  fi
+
   result="$(tun_current_effective_result 2>/dev/null || true)"
   case "${result:-unknown}" in
     ok)
@@ -1032,9 +1045,11 @@ system_state_connectivity_text() {
 }
 
 system_state_risk_text() {
-  load_system_state
+  local risk_level
 
-  case "$RISK_LEVEL" in
+  risk_level="$(system_state_risk_level)"
+
+  case "$risk_level" in
     low) echo "🐱 低" ;;
     medium) echo "🟡 中" ;;
     high) echo "🟠 高" ;;
@@ -5958,6 +5973,7 @@ tun_log_tun_adapter_cidrs() {
 
 tun_ipv4_to_int() {
   local ip="$1"
+  local output_var="$2"
   local a b c d octet n value
 
   IFS=. read -r a b c d <<EOF
@@ -5979,7 +5995,7 @@ EOF
     value=$(((value << 8) + n))
   done
 
-  printf '%s\n' "$value"
+  printf -v "$output_var" '%s' "$value"
 }
 
 tun_ipv4_in_cidr() {
@@ -5999,8 +6015,8 @@ tun_ipv4_in_cidr() {
   prefix=$((10#$prefix))
   [ "$prefix" -ge 0 ] && [ "$prefix" -le 32 ] || return 1
 
-  ip_value="$(tun_ipv4_to_int "$ip" 2>/dev/null)" || return 1
-  base_value="$(tun_ipv4_to_int "$base" 2>/dev/null)" || return 1
+  tun_ipv4_to_int "$ip" ip_value || return 1
+  tun_ipv4_to_int "$base" base_value || return 1
 
   if [ "$prefix" -eq 0 ]; then
     mask=0
@@ -6042,14 +6058,10 @@ EOF
   return 1
 }
 
-tun_log_line_source_ip() {
-  sed -nE 's/.*(^|[^0-9])(([0-9]{1,3}\.){3}[0-9]{1,3}):[0-9]+.*-->.*/\2/p' \
-    | tail -n 1
-}
-
 tun_log_tun_source_line() {
   local log_file="$LOG_DIR/mihomo.out.log"
-  local adapter_cidrs line source_ip matched_line
+  local adapter_cidrs line source_ip
+  local source_pattern='(^|[^0-9])(([0-9]{1,3}\.){3}[0-9]{1,3}):[0-9]+.*-->'
 
   [ -f "$log_file" ] || return 1
   adapter_cidrs="$(tun_log_tun_adapter_cidrs 2>/dev/null || true)"
@@ -6060,16 +6072,19 @@ tun_log_tun_source_line() {
       *) continue ;;
     esac
 
-    source_ip="$(printf '%s\n' "$line" | tun_log_line_source_ip 2>/dev/null || true)"
-    [ -n "${source_ip:-}" ] || continue
+    if [[ "$line" =~ $source_pattern ]]; then
+      source_ip="${BASH_REMATCH[2]}"
+    else
+      continue
+    fi
 
     if tun_log_source_ip_is_tun "$source_ip" "$adapter_cidrs"; then
-      matched_line="$line"
+      printf '%s\n' "$line"
+      return 0
     fi
-  done < "$log_file"
+  done < <(tac "$log_file")
 
-  [ -n "${matched_line:-}" ] || return 1
-  printf '%s\n' "$matched_line"
+  return 1
 }
 
 tun_log_has_tun_traffic_evidence() {

--- a/scripts/dev/check-tun-log-detection.sh
+++ b/scripts/dev/check-tun-log-detection.sh
@@ -71,3 +71,18 @@ run_case \
   "[TUN] Tun adapter listening at: Meta([198.18.0.1/30],[])" \
   "[TCP] 10.0.0.2:43820 --> example.com:443 match RuleSet" \
   "fail"
+
+older_line="[TCP] 198.18.0.2:43820 --> older.example.com:443 match RuleSet"
+newer_line="[TCP] 198.18.0.2:43821 --> newer.example.com:443 match RuleSet"
+printf '%s\n%s\n%s\n' \
+  "[TUN] Tun adapter listening at: Meta([198.18.0.1/30],[])" \
+  "$older_line" \
+  "$newer_line" > "$LOG_DIR/mihomo.out.log"
+
+actual_line="$(tun_log_tun_source_line)"
+if [ "$actual_line" != "$newer_line" ]; then
+  echo "not ok - returns latest tun traffic: got '$actual_line'" >&2
+  exit 1
+fi
+
+echo "ok - returns latest tun traffic"

--- a/scripts/dev/check-tun-policy-routing-status.sh
+++ b/scripts/dev/check-tun-policy-routing-status.sh
@@ -45,6 +45,13 @@ assert_equal \
   "accepts auto-route policy routing when auto-redirect is disabled" \
   "ok" \
   "$(tun_current_effective_result)"
+assert_equal \
+  "status uses local policy routing evidence without a public IP probe" \
+  "effective" \
+  "$(
+    tun_current_effective_result() { printf 'unexpected-public-ip-probe\n'; }
+    status_tun_effective_status
+  )"
 
 # The same classifier must drive both status commands. Without observed traffic,
 # keep the result explicit instead of presenting a false negative.


### PR DESCRIPTION
## What changed

- stop loading the full system state a second time when rendering the compact risk summary
- scan Mihomo traffic logs from newest to oldest and return the first matching TUN record
- parse source addresses with Bash regex matching and avoid per-line `sed`, `tail`, and IPv4 conversion subprocesses
- use existing auto-route policy-routing evidence for the compact TUN status before running public-IP probes
- add regression coverage for newest-log selection and the local policy-routing fast path

## Why

`clash status` appeared to hang with TUN enabled. The compact status path repeatedly evaluated TUN state, scanned the entire growing Mihomo log, and spawned multiple subprocesses for each traffic line. It also waited for public-IP probes even when auto-route policy-routing evidence would determine the same final status.

On the affected host, a roughly 12,700-line Mihomo log made the command take 27.87 seconds and consume about 24 seconds of CPU time. With this change, the same command completes in 1.40 seconds.

The full `clash tun doctor` path still performs active network verification; only the compact status display uses the equivalent local-evidence fast path.

## Validation

- `bash -n scripts/core/clashctl.sh scripts/dev/check-tun-log-detection.sh scripts/dev/check-tun-policy-routing-status.sh`
- `bash scripts/dev/check-tun-log-detection.sh`
- `bash scripts/dev/check-tun-policy-routing-status.sh`
- `bash scripts/dev/check-tun-doctor-runtime-capability.sh`
- `bash scripts/dev/check-tun-proxy-off-shell-restore.sh`
- `git diff --check`

